### PR TITLE
Fix project for use within virtualenv

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright (C) 2013-2016 Florian Festi
 #

--- a/boxes/generators/_template.py
+++ b/boxes/generators/_template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2016 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/box.py
+++ b/boxes/generators/box.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/box2.py
+++ b/boxes/generators/box2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/box3.py
+++ b/boxes/generators/box3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/castle.py
+++ b/boxes/generators/castle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/drillbox.py
+++ b/boxes/generators/drillbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/flexbox.py
+++ b/boxes/generators/flexbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/flexbox2.py
+++ b/boxes/generators/flexbox2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/flexbox3.py
+++ b/boxes/generators/flexbox3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/flexbox4.py
+++ b/boxes/generators/flexbox4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/flextest.py
+++ b/boxes/generators/flextest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/folder.py
+++ b/boxes/generators/folder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/lamp.py
+++ b/boxes/generators/lamp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/magazinefile.py
+++ b/boxes/generators/magazinefile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/printer.py
+++ b/boxes/generators/printer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/silverwarebox.py
+++ b/boxes/generators/silverwarebox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/trayinsert.py
+++ b/boxes/generators/trayinsert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/traylayout.py
+++ b/boxes/generators/traylayout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2016 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/typetray.py
+++ b/boxes/generators/typetray.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/svgutil.py
+++ b/boxes/svgutil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2016 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/scripts/boxes
+++ b/scripts/boxes
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/scripts/boxesserver
+++ b/scripts/boxesserver
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from setuptools import setup, find_packages
 
-setup(name='boxes.py',
+setup(name='boxes',
       version='0.1',
       description='Boxes generator for laser cutters',
       author='Florian Festi',


### PR DESCRIPTION
- Use /usr/bin/env to determine path to python3 instead of a hard-coded
  path, so that virtualenv stubs work properly.
- Change package name to 'boxes' ('boxes.py' did not work within
  virtualenv).