### PR TITLE
Use cairocffi instead of cairo

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -14,6 +14,8 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import cairocffi
+cairocffi.install_as_pycairo()
 import cairo
 import math
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='boxes.py',
       author_email='florian@festi.info',
       url='https://github.com/florianfesti/boxes',
       packages=find_packages(),
-      install_requires=['cairo'],
+      install_requires=['cairocffi'],
       scripts=['scripts/boxes', 'scripts/boxesserver'],
       classifiers=[
           "Development Status :: 4 - Beta",


### PR DESCRIPTION
cairocffi is available from pip, which makes setup much easier.