### PR TITLE
Fix tmp file access in windows

### DIFF
--- a/scripts/boxesserver
+++ b/scripts/boxesserver
@@ -381,8 +381,8 @@ Create boxes and more with a laser cutter!
             fd, box.output = tempfile.mkstemp()
             box.render()
             result = open(box.output).readlines()
-            os.remove(box.output)
             os.close(fd)
+            os.remove(box.output)
             return (l.encode("utf-8") for l in result)
 
 if __name__=="__main__":


### PR DESCRIPTION
Was throwing this error:
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\n\\AppData\\Local\\Temp\\tmpw8emq0xq'

see https://stackoverflow.com/questions/34716996/cant-remove-a-file-which-created-by-tempfile-mkstemp-on-windows