### PR TITLE
create travis build script for doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+  - pip
+branches:
+  only:
+    - master
+install: 
+  - pip install sphinx pycairo
+script:
+  #- python setup.py install
+  - cd ./documentation/src/ && make html #linkchecker
+  - cd ../build/html/ && ls
+
+deploy:
+  provider: pages
+  # see https://docs.travis-ci.com/user/deployment/pages/
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep-history: true
+  local-dir: ./documentation/build/html/
+  on:
+    branch: master

--- a/documentation/src/Makefile
+++ b/documentation/src/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build-3
+SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = ../build
 

--- a/documentation/src/conf.py
+++ b/documentation/src/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION

1. Create token https://docs.travis-ci.com/user/deployment/pages/#setting-the-github-token
2. Add token to settings as `GITHUB_TOKEN` https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings

todo: the `html` subfolder has to be removed from links