### PR TITLE
Add boxes.egg-info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ build/
 dist/
 inkex/*.inx
 boxes.py.egg-info/
+boxes.egg-info/
 .idea


### PR DESCRIPTION
In my environment using python3 in a virtual-environment on Debian GNU/Linux, the .egg-info file does not contain .py, so an extra line in .gitignore is needed

Could be replaced with a pattern like *.egg-info/ but that might be to much :-)