### PR TITLE
box: raise NotImplementedError instead of NotImplemented

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -526,7 +526,7 @@ class Boxes:
         You will typically need to call .parseArgs() before calling this one"""
         self.open()
         # Change settings and creat new Edges and part classes here
-        raise NotImplemented
+        raise NotImplementedError
         self.close()
 
     def cc(self, callback, number, x=0.0, y=None):


### PR DESCRIPTION
NotImplemented is a sentinel for comparisons; encountering this as an
exception would result in a meta-error.

---

Filed as a PR as requested on https://github.com/florianfesti/boxes/pull/132#issuecomment-480578104