### PR TITLE
Lid fixes

### DIFF
--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -1430,6 +1430,8 @@ class LidSettings(FingerJointSettings):
 
     """Settings for Slide-on Lids
 
+Note that edge_width below also determines how much the sides extend above the lid.
+
 Inherited:
 
     """
@@ -1532,6 +1534,7 @@ class LidSideRight(BaseEdge):
         t = self.boxes.thickness
         s = self.settings.play
         pin = self.settings.second_pin
+        edge_width = self.settings.edge_width
 
         if self.rightside:
             spring = self.settings.spring in ("right", "both")
@@ -1539,34 +1542,34 @@ class LidSideRight(BaseEdge):
             spring = self.settings.spring in ("left", "both")
 
         if spring:
-            p = [s, -90, t+s, -90, t+s, 90, t-s, 90, length+t]
+            p = [s, -90, t+s, -90, t+s, 90, edge_width-s, 90, length+t]
         else:
-            p = [t+s, -90, t+s, -90, 2*t+s, 90, t-s, 90, length+t]
+            p = [t+s, -90, t+s, -90, 2*t+s, 90, edge_width-s, 90, length+t]
 
         if pin:
             pinl = 2*t
-            p[-1:] = [p[-1]-t-2*pinl, 90, 2*t+s, -90, 2*pinl+s, -90, t+s, -90,
-                      pinl, 90, t, 90, pinl+t-s]
+            p[-1:] = [p[-1]-t-2*pinl, 90, edge_width+t+s, -90, 2*pinl+s, -90, t+s, -90,
+                      pinl, 90, edge_width, 90, pinl+t-s]
 
         holex = 0.6 * t
         holey = -0.5*t
         if self.rightside:
             p = list(reversed(p))
             holex = length - holex
-            holey = 1.5*t
+            holey = edge_width + 0.5*t
 
         if spring:
             self.rectangularHole(holex, holey, 0.4*t, t+2*s)
         self.polyline(*p)
 
     def startwidth(self):
-        return 2*self.boxes.thickness if self.rightside else 0.0
+        return self.boxes.thickness + self.settings.edge_width if self.rightside else 0.0
 
     def endwidth(self):
-        return 2*self.boxes.thickness if not self.rightside else 0.0
+        return self.boxes.thickness + self.settings.edge_width if not self.rightside else 0.0
 
     def margin(self):
-        return 2*self.boxes.thickness if not self.rightside else 0.0
+        return self.boxes.thickness + self.settings.edge_width if not self.rightside else 0.0
 
 class LidSideLeft(LidSideRight):
     char = "M"

--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -716,7 +716,7 @@ class FingerHoleEdge(BaseEdge):
         dist = self.fingerHoles.settings.edge_width
         with self.saved_context():
             self.fingerHoles(
-                0, dist + self.settings.thickness / 2, length, 0,
+                0, self.burn + dist + self.settings.thickness / 2, length, 0,
                 bedBolts=bedBolts, bedBoltSettings=bedBoltSettings)
         self.edge(length, tabs=2)
 

--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -1542,17 +1542,17 @@ class LidSideRight(BaseEdge):
             spring = self.settings.spring in ("left", "both")
 
         if spring:
-            p = [s, -90, t+s, -90, t+s, 90, edge_width-s, 90, length+t]
+            p = [s, -90, t+s, -90, t+s, 90, edge_width-s/2, 90, length+t]
         else:
-            p = [t+s, -90, t+s, -90, 2*t+s, 90, edge_width-s, 90, length+t]
+            p = [t+s, -90, t+s, -90, 2*t+s, 90, edge_width-s/2, 90, length+t]
 
         if pin:
             pinl = 2*t
-            p[-1:] = [p[-1]-t-2*pinl, 90, edge_width+t+s, -90, 2*pinl+s, -90, t+s, -90,
-                      pinl, 90, edge_width, 90, pinl+t-s]
+            p[-1:] = [p[-1]-t-2*pinl, 90, edge_width+t+s/2, -90, 2*pinl+s, -90, t+s, -90,
+                      pinl, 90, edge_width-s/2, 90, pinl+t-s]
 
         holex = 0.6 * t
-        holey = -0.5*t + self.burn
+        holey = -0.5*t + self.burn - s / 2
         if self.rightside:
             p = list(reversed(p))
             holex = length - holex
@@ -1563,13 +1563,13 @@ class LidSideRight(BaseEdge):
         self.polyline(*p)
 
     def startwidth(self):
-        return self.boxes.thickness + self.settings.edge_width if self.rightside else 0.0
+        return self.boxes.thickness + self.settings.edge_width if self.rightside else -self.settings.play / 2
 
     def endwidth(self):
-        return self.boxes.thickness + self.settings.edge_width if not self.rightside else 0.0
+        return self.boxes.thickness + self.settings.edge_width if not self.rightside else -self.settings.play / 2
 
     def margin(self):
-        return self.boxes.thickness + self.settings.edge_width if not self.rightside else 0.0
+        return self.boxes.thickness + self.settings.edge_width + self.settings.play / 2 if not self.rightside else 0.0
 
 class LidSideLeft(LidSideRight):
     char = "M"

--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -1461,11 +1461,11 @@ Inherited:
 
 class LidEdge(FingerJointEdge):
     char = "l"
-    description = "Edge for slide on lid"
+    description = "Edge for slide on lid (back)"
 
 class LidHoleEdge(FingerHoleEdge):
     char = "L"
-    description = "Edge for slide on lid"
+    description = "Edge for slide on lid (box back)"
 
 class LidRight(BaseEdge):
     char = "n"

--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -1552,11 +1552,11 @@ class LidSideRight(BaseEdge):
                       pinl, 90, edge_width, 90, pinl+t-s]
 
         holex = 0.6 * t
-        holey = -0.5*t
+        holey = -0.5*t + self.burn
         if self.rightside:
             p = list(reversed(p))
             holex = length - holex
-            holey = edge_width + 0.5*t
+            holey = edge_width + 0.5*t + self.burn
 
         if spring:
             self.rectangularHole(holex, holey, 0.4*t, t+2*s)


### PR DESCRIPTION
This PR fixes a number of problems in the way burn and play were handled
for lids. These bugs would cause misalignment between the two pin slots
that anchor the lid and between the lid and the finger holes where it
should slide in.

To illustrate these problems, I'm using the universalbox generator, with
the following patch applied. This patch skips one wall, which causes the
back wall and one side wall to end up adjacent, which makes it trivial
to check the alignment of the pin slots in the side and the finger holes
in the back.

```patch
--- a/boxes/generators/universalbox.py
+++ b/boxes/generators/universalbox.py
@@ -84,8 +84,8 @@ class UniversalBox(_TopEdge, _ChestLid):
 
         self.rectangularWall(x, h, [b, "F", t3, "F"],
                              bedBolts=[d2], move="right only")
-        self.rectangularWall(y, h, [b, "f", t2, "f"],
-                             bedBolts=[d3], move="up")
+        #self.rectangularWall(y, h, [b, "f", t2, "f"],
+        #                     bedBolts=[d3], move="up")
         self.rectangularWall(y, h, [b, "f", t4, "f"],
                              bedBolts=[d3], move="up")
 
```

With this patch applied, you can reproduce the problem with the finger and
spring hole positions due to burn with:

    $ boxes Universalbox --x 30 --y 30 --top_edge=L --bottom_edge=e --burn=.2 --Lid_play=0                                                                    

![image](https://user-images.githubusercontent.com/194491/61983736-d7978c80-b001-11e9-8a65-656626eded51.png)

Note the (blue) finger hole on the right which shifted, as well as the (blue)
spring hole on the left. Also note that the position of the two pin slots on
the left (in black) is correct, 2x3mm from the top.

To reproduce the problem with space/play, run:

    $ boxes Universalbox --x 30 --y 30 --top_edge=L --bottom_edge=e --burn=0 --Lid_play=0.1                                                                   

![image](https://user-images.githubusercontent.com/194491/61983677-9dc68600-b001-11e9-9f39-b968fabd1676.png)

Here, the guides are placed in the canonical position of the lid (e.g. without
any play applied). You can see that the play is added below for the left slot
and above for the right slot. Note that the play is evenly distributed for the
(blue) hole (whose position is correct because the burn is set to 0).

I also added a commit (the first) that slightly improves some comments,
and added a commit that lets edge_width be consistently be interpreted
(the back wall / finger holes edge already did, now the side walls also
do, which allows added a bit of extra space above the lid, which can be
useful when using thing material).

With this PR applied, both burn and play result in a symmetrical aligned result:

    $ boxes Universalbox --x 30 --y 30 --top_edge=L --bottom_edge=e --burn=0.2 --Lid_play=0.1

![image](https://user-images.githubusercontent.com/194491/61983873-5391d480-b002-11e9-816c-e2e2b580e8b4.png)

Note that the finger holes are slightly larger, IIRC the holes apply the play on both sides in whole, while the pin slots divide the play over both sides.