### PR TITLE
Redefine server port+manpages

### DIFF
--- a/documentation/boxes.1
+++ b/documentation/boxes.1
@@ -1,0 +1,63 @@
+'\" t
+.\"     Title: Boxes
+.\"    Author: Georges Khaznadar <georgesk@debian.org>
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 10/26/2019
+.\"    Manual: boxes User Manual
+.\"    Source: boxes
+.\"  Language: English
+.\"
+.TH "BOXES" "1" "10/26/2019" "boxes" "boxes User Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+boxes \- program design boxes
+.SH "DESCRIPTION"
+.PP
+\fBboxes\fR
+is a program that generates SVG images that can be viewed directly in a web brower but also postscript and \- with pstoedit as external helper \- other vector formats including dxf, plt (aka hpgl) and gcode\&.
+.PP
+Of course the library and the generators allow selecting the "thickness" of the material used and automatically adjusts lengths and width of joining fingers and other elements\&.
+.PP
+The "burn" parameter compensates for the material removed by the laser\&. This allows fine tuning the gaps between joins up to the point where plywood can be press fitted even without any glue\&.
+.PP
+inger Joints are the work horse of the library\&. They allow 90\(de edges and T connections\&. Their size is scaled up with the material "thickness" to maintain the same appearance\&. The library also allows putting holes and slots for screws (bed bolts) into finger joints, although this is currently not supported for the included generators\&.
+.PP
+Dovetail joints can be used to join pieces in the same plane\&.
+.PP
+Flex cuts allows bending and stretching the material in one direction\&. This is used for rounded edges and living hinges\&.
+.SH "AUTHOR"
+.PP
+\fBGeorges Khaznadar\fR <\&georgesk@debian\&.org\&>
+.RS 4
+Wrote this manpage for the Debian system\&.
+.RE
+.SH "COPYRIGHT"
+.br
+Copyright \(co 2019 Georges Khaznadar
+.br
+.PP
+This manual page was written for the Debian system (and may be used by others)\&.
+.PP
+Permission is granted to copy, distribute and/or modify this document under the terms of the GNU General Public License, Version 2 or (at your option) any later version published by the Free Software Foundation\&.
+.PP
+On Debian systems, the complete text of the GNU General Public License can be found in
+/usr/share/common\-licenses/GPL\&.
+.sp

--- a/documentation/boxes.xml
+++ b/documentation/boxes.xml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+
+<!--
+
+`xsltproc -''-nonet \
+          -''-param man.charmap.use.subset "0" \
+          -''-param make.year.ranges "1" \
+          -''-param make.single.year.ranges "1" \
+          /usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl \
+          manpage.xml'
+
+A manual page <package>.<section> will be generated. You may view the
+manual page with: nroff -man <package>.<section> | less'. A typical entry
+in a Makefile or Makefile.am is:
+
+DB2MAN = /usr/share/sgml/docbook/stylesheet/xsl/docbook-xsl/manpages/docbook.xsl
+XP     = xsltproc -''-nonet -''-param man.charmap.use.subset "0"
+
+manpage.1: manpage.xml
+        $(XP) $(DB2MAN) $<
+
+The xsltproc binary is found in the xsltproc package. The XSL files are in
+docbook-xsl. A description of the parameters you can use can be found in the
+docbook-xsl-doc-* packages. Please remember that if you create the nroff
+version in one of the debian/rules file targets (such as build), you will need
+to include xsltproc and docbook-xsl in your Build-Depends control field.
+Alternatively use the xmlto command/package. That will also automatically
+pull in xsltproc and docbook-xsl.
+
+Notes for using docbook2x: docbook2x-man does not automatically create the
+AUTHOR(S) and COPYRIGHT sections. In this case, please add them manually as
+<refsect1> ... </refsect1>.
+
+To disable the automatic creation of the AUTHOR(S) and COPYRIGHT sections
+read /usr/share/doc/docbook-xsl/doc/manpages/authors.html. This file can be
+found in the docbook-xsl-doc-html package.
+
+Validation can be done using: `xmllint -''-noout -''-valid manpage.xml`
+
+General documentation about man-pages and man-page-formatting:
+man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
+
+-->
+
+  <!-- Fill in your name for FIRSTNAME and SURNAME. -->
+  <!ENTITY dhfirstname "Georges">
+  <!ENTITY dhsurname   "Khaznadar">
+  <!-- dhusername could also be set to "&dhfirstname; &dhsurname;". -->
+  <!ENTITY dhusername  "Georges Khaznadar">
+  <!ENTITY dhemail     "georgesk@debian.org">
+  <!-- SECTION should be 1-8, maybe w/ subsection other parameters are
+       allowed: see man(7), man(1) and
+       http://www.tldp.org/HOWTO/Man-Page/q2.html. -->
+  <!ENTITY dhsection   "1">
+  <!-- TITLE should be something like "User commands" or similar (see
+       http://www.tldp.org/HOWTO/Man-Page/q2.html). -->
+  <!ENTITY dhtitle     "boxes User Manual">
+  <!ENTITY dhucpackage "Boxes">
+  <!ENTITY dhpackage   "boxes">
+]>
+
+<refentry>
+  <refentryinfo>
+    <title>&dhtitle;</title>
+    <productname>&dhpackage;</productname>
+    <authorgroup>
+      <author>
+       <firstname>&dhfirstname;</firstname>
+        <surname>&dhsurname;</surname>
+        <contrib>Wrote this manpage for the Debian system.</contrib>
+        <address>
+          <email>&dhemail;</email>
+        </address>
+      </author>
+    </authorgroup>
+    <copyright>
+      <year>2019</year>
+      <holder>&dhusername;</holder>
+    </copyright>
+    <legalnotice>
+      <para>This manual page was written for the Debian system
+        (and may be used by others).</para>
+      <para>Permission is granted to copy, distribute and/or modify this
+        document under the terms of the GNU General Public License,
+        Version 2 or (at your option) any later version published by
+        the Free Software Foundation.</para>
+      <para>On Debian systems, the complete text of the GNU General Public
+        License can be found in
+        <filename>/usr/share/common-licenses/GPL</filename>.</para>
+    </legalnotice>
+  </refentryinfo>
+  <refmeta>
+    <refentrytitle>&dhucpackage;</refentrytitle>
+    <manvolnum>&dhsection;</manvolnum>
+  </refmeta>
+  <refnamediv>
+    <refname>&dhpackage;</refname>
+    <refpurpose>program design boxes</refpurpose>
+  </refnamediv>
+  <refsect1 id="description">
+    <title>DESCRIPTION</title>
+    <para>
+      <command>&dhpackage;</command> is a program that generates
+      SVG images that can be viewed directly in a web brower but also
+      postscript and - with pstoedit as external helper -
+      other vector formats including dxf, plt (aka hpgl) and gcode.
+    </para>
+    <para>
+      Of course the library and the generators allow selecting the
+      "thickness" of the material used and automatically adjusts lengths and
+      width of joining fingers and other elements.
+    </para>
+    <para>
+      The "burn" parameter compensates for the material removed by the
+      laser. This allows fine tuning the gaps between joins up to the point
+      where plywood can be press fitted even without any glue.
+    </para>
+    <para>
+      inger Joints are the work horse of the library. They allow 90°
+      edges and T connections. Their size is scaled up with the material
+      "thickness" to maintain the same appearance. The library also allows
+      putting holes and slots for screws (bed bolts) into finger joints,
+      although this is currently not supported for the included generators.
+    </para>
+    <para>
+      Dovetail joints can be used to join pieces in the same plane.
+    </para>
+    <para>
+      Flex cuts allows bending and stretching the material in one
+      direction. This is used for rounded edges and living hinges.
+    </para>
+  </refsect1>
+</refentry>
+

--- a/documentation/boxesserver.1
+++ b/documentation/boxesserver.1
@@ -1,0 +1,64 @@
+'\" t
+.\"     Title: BoxesServer
+.\"    Author: Georges Khaznadar <georgesk@debian.org>
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 10/31/2019
+.\"    Manual: boxesserver User Manual
+.\"    Source: boxesserver
+.\"  Language: English
+.\"
+.TH "BOXESSERVER" "1" "10/31/2019" "boxesserver" "boxesserver User Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+boxesserver \- a web server to make boxes\&.
+.SH "SYNOPSIS"
+.HP \w'\fBboxesserver\fR\ 'u
+\fBboxesserver\fR [\fB\fIport_number\fR\fR]
+.SH "DESCRIPTION"
+.PP
+\fBboxesserver\fR
+is a web server which allows one to compute sketches to cut materials with a laser and make various types of boxes\&.
+.SH "OPTIONS"
+.PP
+\fB\fIport_number\fR\fR
+.RS 4
+If this optional parameter is set, the web service will be done using this port number\&. By default, the port number is 8000\&.
+.sp
+Please notice that port numbers lesser than 1024 are privileged, and can be used only by root\&.
+.RE
+.SH "AUTHOR"
+.PP
+\fBGeorges Khaznadar\fR <\&georgesk@debian\&.org\&>
+.RS 4
+Wrote this manpage for the Debian system\&.
+.RE
+.SH "COPYRIGHT"
+.br
+Copyright \(co 2019 Georges Khaznadar
+.br
+.PP
+This manual page was written for the Debian system (and may be used by others)\&.
+.PP
+Permission is granted to copy, distribute and/or modify this document under the terms of the GNU General Public License, Version 2 or (at your option) any later version published by the Free Software Foundation\&.
+.PP
+On Debian systems, the complete text of the GNU General Public License can be found in
+/usr/share/common\-licenses/GPL\&.
+.sp

--- a/documentation/boxesserver.xml
+++ b/documentation/boxesserver.xml
@@ -1,0 +1,133 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+
+<!--
+
+`xsltproc -''-nonet \
+          -''-param man.charmap.use.subset "0" \
+          -''-param make.year.ranges "1" \
+          -''-param make.single.year.ranges "1" \
+          /usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl \
+          boxesserver.xml'
+
+A manual page <package>.<section> will be generated. You may view the
+manual page with: nroff -man <package>.<section> | less'. A typical entry
+in a Makefile or Makefile.am is:
+
+DB2MAN = /usr/share/sgml/docbook/stylesheet/xsl/docbook-xsl/manpages/docbook.xsl
+XP     = xsltproc -''-nonet -''-param man.charmap.use.subset "0"
+
+manpage.1: manpage.xml
+        $(XP) $(DB2MAN) $<
+
+The xsltproc binary is found in the xsltproc package. The XSL files are in
+docbook-xsl. A description of the parameters you can use can be found in the
+docbook-xsl-doc-* packages. Please remember that if you create the nroff
+version in one of the debian/rules file targets (such as build), you will need
+to include xsltproc and docbook-xsl in your Build-Depends control field.
+Alternatively use the xmlto command/package. That will also automatically
+pull in xsltproc and docbook-xsl.
+
+Notes for using docbook2x: docbook2x-man does not automatically create the
+AUTHOR(S) and COPYRIGHT sections. In this case, please add them manually as
+<refsect1> ... </refsect1>.
+
+To disable the automatic creation of the AUTHOR(S) and COPYRIGHT sections
+read /usr/share/doc/docbook-xsl/doc/manpages/authors.html. This file can be
+found in the docbook-xsl-doc-html package.
+
+Validation can be done using: `xmllint -''-noout -''-valid manpage.xml`
+
+General documentation about man-pages and man-page-formatting:
+man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
+
+-->
+
+  <!-- Fill in your name for FIRSTNAME and SURNAME. -->
+  <!ENTITY dhfirstname "Georges">
+  <!ENTITY dhsurname   "Khaznadar">
+  <!-- dhusername could also be set to "&dhfirstname; &dhsurname;". -->
+  <!ENTITY dhusername  "Georges Khaznadar">
+  <!ENTITY dhemail     "georgesk@debian.org">
+  <!-- SECTION should be 1-8, maybe w/ subsection other parameters are
+       allowed: see man(7), man(1) and
+       http://www.tldp.org/HOWTO/Man-Page/q2.html. -->
+  <!ENTITY dhsection   "1">
+  <!-- TITLE should be something like "User commands" or similar (see
+       http://www.tldp.org/HOWTO/Man-Page/q2.html). -->
+  <!ENTITY dhtitle     "boxesserver User Manual">
+  <!ENTITY dhucpackage "BoxesServer">
+  <!ENTITY dhpackage   "boxesserver">
+]>
+
+<refentry>
+  <refentryinfo>
+    <title>&dhtitle;</title>
+    <productname>&dhpackage;</productname>
+    <authorgroup>
+      <author>
+       <firstname>&dhfirstname;</firstname>
+        <surname>&dhsurname;</surname>
+        <contrib>Wrote this manpage for the Debian system.</contrib>
+        <address>
+          <email>&dhemail;</email>
+        </address>
+      </author>
+    </authorgroup>
+    <copyright>
+      <year>2019</year>
+      <holder>&dhusername;</holder>
+    </copyright>
+    <legalnotice>
+      <para>This manual page was written for the Debian system
+        (and may be used by others).</para>
+      <para>Permission is granted to copy, distribute and/or modify this
+        document under the terms of the GNU General Public License,
+        Version 2 or (at your option) any later version published by
+        the Free Software Foundation.</para>
+      <para>On Debian systems, the complete text of the GNU General Public
+        License can be found in
+        <filename>/usr/share/common-licenses/GPL</filename>.</para>
+    </legalnotice>
+  </refentryinfo>
+  <refmeta>
+    <refentrytitle>&dhucpackage;</refentrytitle>
+    <manvolnum>&dhsection;</manvolnum>
+  </refmeta>
+  <refnamediv>
+    <refname>&dhpackage;</refname>
+    <refpurpose>a web server to make boxes.</refpurpose>
+  </refnamediv>
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      <command>&dhpackage;</command>
+      <arg choice="opt"><option><replaceable>port_number</replaceable></option></arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+  <refsect1 id="description">
+    <title>DESCRIPTION</title>
+    <para><command>&dhpackage;</command> is a web server which allows
+    one to compute sketches to
+    cut materials with a laser and make various types of boxes.</para>
+  </refsect1>
+  <refsect1 id="options">
+    <title>OPTIONS</title>
+    <variablelist>
+      <varlistentry>
+        <term><option><replaceable>port_number</replaceable></option></term>
+        <listitem>
+	  <para>If this optional parameter is set, the web service
+	  will be done using this port number. By default, the port number
+	  is 8000.
+	  </para>
+	  <para>
+	    Please notice that port numbers lesser than 1024 are privileged,
+	    and can be used only by root.
+	  </para>
+	</listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+</refentry>
+

--- a/scripts/boxesserver
+++ b/scripts/boxesserver
@@ -517,11 +517,15 @@ class BServer:
             return (l.encode("utf-8") for l in result)
 
 if __name__=="__main__":
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])
+    else:
+        port = 8000
     fc = FileChecker()
     fc.start()
     boxserver = BServer()
-    httpd = make_server('', 8000, boxserver.serve)
-    print("Serving on port 8000...")
+    httpd = make_server('', port, boxserver.serve)
+    print("BoxesServer serving on port %s..." %port)
     httpd.serve_forever()
 else:
     application = BServer().serve


### PR DESCRIPTION
Hello, this PR allows one to give an optional parameter to the script boxesserver, in order to use another port than the default 8000.
Additionally, simple manpages have been written for user-space scripts. boxesserver's manpage documents the optional parameter to change the port.