### PR TITLE
Setup for debian

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,8 @@ class CustomBuildExtCommand(build_py):
         self.execute(self.generate_mo_files, ())
         self.execute(self.buildInkscapeExt, ())
 
-        if 'FAKEROOTKEY' in os.environ:
-            # we are probably running under fakeroot
-            # so we are probably building a Debian package
+        if 'CURRENTLY_PACKAGING' in os.environ:
+            # we are most probably building a Debian package
             # let us define a simple path!
             path="/usr/share/inkscape/extensions"
             self.distribution.data_files.append(


### PR DESCRIPTION
Hello, now the PR is mature.

When setup.py is run inside a packaging routine, one has to define an environment variable named
CURRENTLY_PACKAGING, and a special behaviour is used by setup.py to comply with the
File Hierarchy Standard.

This patch does not modify setup.py's behavior for ordinary builds.