### PR TITLE
add requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+affine
+markdown
+lxml
+setuptools
+sphinx


### PR DESCRIPTION
Rather than interpreting the readme, if we include a requirements.txt file we can automate the dependencies.