### PR TITLE
Clarify rectangularHole x,y parameters (center)

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -1181,10 +1181,10 @@ class Boxes:
     @holeCol
     def rectangularHole(self, x, y, dx, dy, r=0):
         """
-        Draw an rectangulat hole
+        Draw an rectangular hole
 
-        :param x: position
-        :param y: position
+        :param x: position of the center
+        :param y: position of the center
         :param dx: width
         :param dy: height
         :param r:  (Default value = 0) radius of the corners


### PR DESCRIPTION
In rectangularHole documentation:

- fixes a typo (rectangula_t_) 
- clarifies the fact that x and y are the center of the rectangle

Thank you !