### PR TITLE
Add generators for marble run parts

### DIFF
--- a/boxes/generators/marblecatcher.py
+++ b/boxes/generators/marblecatcher.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (C) 2020  Luca Schmid
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from boxes import *
+from math import atan, degrees, fmod, sqrt
+
+class MarbleCatcher(Boxes):
+    """Box for catching marbles at the end of their journey"""
+
+    ui_group = "Unstable"
+
+    def __init__(self):
+        Boxes.__init__(self)
+
+        self.addSettingsArgs(edges.FingerJointSettings, surroundingspaces=1.0, finger=2.0, space=2.0)
+
+        self.buildArgParser(x=100, y=28, h=22, outside=True)
+        self.argparser.add_argument("--grid", type=float, default=15.0, help="grid spacing")
+        self.argparser.add_argument("--numclips", type=int, default=2, help="number of clips")
+
+
+    def rectangularWallWithClips(self, x, y, edges="eeee", move=None, num_clips=[0,0,0,0], draw_clips=True):
+        """
+        Rectangular wall with clips for box like objects
+
+        :param x: width
+        :param y: height
+        :param edges:  (Default value = "eeee") bottom, right, top, left
+        :param move:  (Default value = None)
+        :param num_clips: (Default value = [0,0,0,0]) number of clips to add bottom, right, top, left
+        :param draw_clips: (Default value = True) whether or not to actually draw clips
+
+        """
+        if len(edges) != 4:
+            raise ValueError("four edges required")
+        edges = [self.edges.get(e, e) for e in edges]
+
+        bottom = self.grid if draw_clips and num_clips[0] > 0 else 0
+        right = self.grid if draw_clips and num_clips[1] > 0 else 0
+        top = self.grid if draw_clips and num_clips[2] > 0 else 0
+        left = self.grid if draw_clips and num_clips[-1] > 0 else 0
+        overallwidth = x + edges[-1].spacing() + edges[1].spacing() + left + right
+        overallheight = y + edges[0].spacing() + edges[2].spacing() + bottom + top
+
+        if self.move(overallwidth, overallheight, move, before=True):
+            return
+
+        self.moveTo(edges[-1].spacing())
+        self.moveTo(0, edges[0].margin())
+        self.moveTo(left, bottom)
+        for i, l in enumerate((x, y, x, y)):
+            e1, e2 = edges[i], edges[(i+1)%4]
+            n = num_clips[i]
+
+            if n:
+                s = (l-self.grid*n) / (n+1)
+                r = fmod(s, self.grid)
+                q = s - r
+                p = r * (n+1) / 2
+
+                a = (self.grid - self.thickness) / 2
+                c = self.grid - a
+                for j in range(n):
+                    edges[i]((p if j == 0 else 0) + q)
+                    if draw_clips:
+                        self.corner(-90)
+                        self.edge(c)
+                        self.corner(90, a)
+                        self.corner(90)
+                        self.edge(self.grid)
+                        self.corner(-90)
+                        self.edge(self.thickness)
+                        self.corner(-90)
+                        self.edge(self.grid)
+                        self.corner(90)
+                        self.corner(90, a)
+                        self.edge(c)
+                        self.corner(-90)
+                    else:
+                        self.edge(self.grid)
+                edges[i](q+p)
+            else:
+                edges[i](l)
+            self.edgeCorner(e1, e2, 90)
+
+        self.move(overallwidth, overallheight, move)
+
+
+    def render(self):
+        x, y, h, grid = self.x, self.y, self.h, self.grid
+
+        if self.outside:
+            x = self.adjustSize(x)
+            y = self.adjustSize(y)
+            h = self.adjustSize(h)
+
+        self.rectangularWallWithClips(x, y, 'ffff', move='down', num_clips=[self.numclips,0]*2, draw_clips=False)
+        self.rectangularWall(y, h, 'hfef', move='down')
+        self.rectangularWallWithClips(x, h, 'hFeF', move='down', num_clips=[self.numclips,0,0,0])
+        self.rectangularWall(y, h, 'hfef', move='down')
+        self.rectangularWallWithClips(x, h, 'hFeF', move='down', num_clips=[self.numclips,0,0,0])
+
+

--- a/boxes/generators/marbleslide.py
+++ b/boxes/generators/marbleslide.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (C) 2020  Luca Schmid
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from boxes import *
+from math import sqrt
+
+class MarbleSlide(Boxes):
+    """Generate a simple slide for marbles"""
+
+    ui_group = "Unstable"
+
+    def __init__(self):
+        Boxes.__init__(self)
+
+        self.addSettingsArgs(edges.FingerJointSettings, surroundingspaces=1.0, finger=2.0, space=2.0)
+
+        self.buildArgParser(x=200, y=28, h=15, outside=True)
+        self.argparser.add_argument('--grid', type=float, default=15.0, help="grid spacing")
+
+
+    def calcNotchDimensions(self):
+        dh = sqrt(self.thickness**2/2)
+        h = (self.h if self.outside else self.h+self.thickness*2) / 5 * 3
+        return dh, h
+
+
+    def rectangularWallWithNotch(self, x, y, edges="eeee", move=None):
+        """
+        Rectangular wall with notch
+
+        :param x: width
+        :param y: height
+        :param edges:  (Default value = "eeee") bottom, right, top, left
+        :param move:  (Default value = None)
+
+        """
+        if len(edges) != 4:
+            raise ValueError("four edges required")
+        edges = [self.edges.get(e, e) for e in edges]
+
+        overallwidth = x + edges[-1].spacing() + edges[1].spacing()
+        overallheight = y + edges[0].spacing() + edges[2].spacing()
+        dh, h = self.calcNotchDimensions()
+
+        if self.move(overallwidth, overallheight, move, before=True):
+            return
+
+        self.moveTo(edges[-1].spacing())
+        self.moveTo(0, edges[0].margin())
+        for i, l in enumerate((x, y, x, y)):
+            e1, e2 = edges[i], edges[(i+1)%4]
+
+            if i == 0:
+                self.edge(self.thickness+dh)
+                self.corner(90)
+                self.edge(h-2*dh)
+                self.corner(45)
+                self.edge(self.thickness)
+                self.corner(-90)
+                self.edge(self.thickness)
+                self.corner(-45)
+                self.edge(self.thickness)
+                self.corner(-90)
+                self.edge(self.thickness)
+                self.corner(45)
+                self.edge(sqrt((h-self.thickness)**2*2))
+                self.corner(45)
+                edges[i](l-(self.thickness+dh+h))
+            elif i == 3:
+                edges[i](l+self.thickness*2)
+            else:
+                edges[i](l)
+            self.edgeCorner(e1, self.edges['e'] if i == 3 else e2, 90)
+
+        self.move(overallwidth, overallheight, move)
+
+
+    def render(self):
+        x, y, h, grid = self.x, self.y, self.h, self.grid
+        ho = h + self.thickness*2
+
+        if self.outside:
+            x = self.adjustSize(x)
+            y = self.adjustSize(y)
+            ho = h
+            h = self.adjustSize(h)
+
+        dh, nh = self.calcNotchDimensions()
+
+        self.rectangularWall(x-(self.thickness+dh+nh), y, 'fefe', move='down')
+        self.rectangularWall(y, ho, 'efef', move='down')
+        self.rectangularWallWithNotch(x, h, 'heeh', move='down')
+        self.rectangularWallWithNotch(x, h, 'heeh', move='down mirror')
+
+

--- a/boxes/generators/marblesupport.py
+++ b/boxes/generators/marblesupport.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (C) 2020  Luca Schmid
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from boxes import *
+from math import atan, degrees, floor, fmod, sqrt
+
+class MarbleSupport(Boxes):
+    """Support piece for other Marble* parts"""
+
+    ui_group = "Unstable"
+
+    def __init__(self):
+        Boxes.__init__(self)
+
+        self.buildArgParser(x=28.0, y=15.0) # outer dimensions (x_o, y_o) are (x + depth + thickness, y_o = y + 2 * dia)
+        self.argparser.add_argument("--grid", type=float, default=15.0, help="grid spacing")
+        self.argparser.add_argument("--dia", type=float, default=4.8, help="grid hole diameter")
+        self.argparser.add_argument("--depth", type=float, default=4.0, help="grid hole depth")
+
+
+    def pin(self, dia, depth):
+        a = depth / 2
+        b = dia / 24
+        c = sqrt(a**2+b**2)
+        alpha = degrees(atan(b/a))
+
+        self.edge(a)
+        self.corner(alpha)
+        self.edge(c)
+        self.corner(90-alpha)
+        self.edge(dia-b*2)
+        self.corner(90-alpha)
+        self.edge(c)
+        self.corner(alpha)
+        self.edge(a)
+        self.corner(-90)
+
+
+    def render(self):
+        x, y, grid, dia, d = self.x, self.y, self.grid, self.dia, self.depth
+        t = self.thickness
+
+        w = x + t
+
+        n = floor(y / grid)
+        r = fmod(y, grid) / 2
+        s = 3*w/4
+        alpha = degrees(atan(y/s))
+
+        self.moveTo(d, r)
+        self.edge(w/4)
+        self.corner(alpha)
+        self.edge(sqrt(s**2+y**2))
+        self.corner(90-alpha)
+        self.edge(2*dia)
+        self.corner(90)
+        self.edge(t)
+        self.corner(90)
+        self.edge(dia)
+        self.corner(-90)
+        self.edge(x)
+
+        if r > 0:
+            self.corner(90)
+            self.edge(r)
+            self.corner(-90)
+
+        for _ in range(n):
+            self.pin(dia, d)
+            self.edge(grid-dia)
+            self.corner(-90)
+        self.pin(dia, d)
+
+        if r > 0:
+            self.edge(r)
+            self.corner(90)
+
+


### PR DESCRIPTION
### MarbleCatcher

An arbitrarily-sized box with an open top and a customizable number of clips, which (together with `MarbleSupport` parts) are used to attach it to a breadboard.

### MarbleSlide

A marble slide with a notch in one side, so it can be "hung" on one `MarbleSupport` and stabilized with another opposite to the notch. Supports slopes from horizontal to 100%.

### MarbleSupport

The aforementioned support part for mounting other parts to a board of evenly spaced holes (default spacing is 15mm).