### PR TITLE
Keyboards: refactor common code and add options for atreus and keypad

### DIFF
--- a/boxes/generators/atreus21.py
+++ b/boxes/generators/atreus21.py
@@ -71,20 +71,21 @@ class Atreus21(Boxes, Keyboard):
             x, y
         )
 
+    @restore
     def rim(self):
         x, y = self._case_x_y()
         self.moveTo(x * .5, y * .5)
         self.rectangularHole(0, 0, x, y, 5)
-        self.moveTo(x * -.5, y * -.5)
 
+    @restore
     def outer(self):
         x, y = self._case_x_y()
         b = self.border
         self.moveTo(0, -b)
         corner = [90, b]
         self.polyline(*([x, corner, y, corner] * 2))
-        self.moveTo(0, b)
 
+    @restore
     def half(self, hole_cb=None, reverse=False):
         if hole_cb == None:
             hole_cb = self.key
@@ -92,10 +93,8 @@ class Atreus21(Boxes, Keyboard):
         self.apply_callback_on_columns(
             hole_cb,
             self.columns_definition,
-            self.STANDARD_KEY_SPACING,
-            reverse,
+            reverse=reverse,
         )
-        self.moveTo(-self.half_btn, -self.half_btn)
 
     def support(self):
         self.configured_plate_cutout(support=True)

--- a/boxes/generators/atreus21.py
+++ b/boxes/generators/atreus21.py
@@ -14,11 +14,12 @@ class Atreus21(Boxes, Keyboard):
     half_btn = btn_size / 2
     border = 6
 
-    row_offsets=[3, 6, 11, 5, 0, btn_size * .5]
-    row_keys=[4, 4, 4, 4, 4, 1]
-
     def __init__(self):
         super().__init__()
+        self.add_common_keyboard_parameters(
+            # By default, columns from Atreus 21
+            default_columns_definition='4@3/4@6/4@11/4@5/4@0/1@{}'.format(self.btn_size * 0.5)
+        )
 
     def render(self):
         """Renders the keyboard."""
@@ -85,36 +86,35 @@ class Atreus21(Boxes, Keyboard):
         self.moveTo(0, b)
 
     def half(self, hole_cb=None, reverse=False):
-        row_offsets=self.row_offsets
-        row_keys=self.row_keys
-        scheme = list(zip(row_offsets, row_keys))
         if hole_cb == None:
             hole_cb = self.key
         self.moveTo(self.half_btn, self.half_btn)
         self.apply_callback_on_columns(
             hole_cb,
-            scheme,
+            self.columns_definition,
             self.STANDARD_KEY_SPACING,
             reverse,
         )
         self.moveTo(-self.half_btn, -self.half_btn)
 
     def support(self):
-        self.outer_hole()
+        self.configured_plate_cutout(support=True)
 
     def hotplug(self):
-        self.pcb_holes()
+        self.pcb_holes(
+            with_hotswap=self.hotswap_enable,
+            with_pcb_mount=self.pcb_mount_enable,
+            with_diode=self.diode_enable,
+            with_led=self.led_enable,
+        )
 
     def key(self):
-        self.castle_shaped_plate_cutout()
+        self.configured_plate_cutout()
 
     # get case sizes
     def _case_x_y(self):
-        margin = self.STANDARD_KEY_SPACING - self.btn_size
-        x = len(self.row_offsets) * self.STANDARD_KEY_SPACING - margin
-        y = sum([
-            max(self.row_keys) * self.STANDARD_KEY_SPACING,  # total button sizes
-            max(self.row_offsets),  # offset of highest row
-            -margin,
-        ])
+        spacing = Keyboard.STANDARD_KEY_SPACING
+        margin = spacing - self.btn_size
+        x = len(self.columns_definition) * spacing - margin
+        y = max(offset + keys * spacing for (offset, keys) in self.columns_definition) - margin
         return x, y

--- a/boxes/generators/atreus21.py
+++ b/boxes/generators/atreus21.py
@@ -18,69 +18,45 @@ class Atreus21(Boxes):
 
     def __init__(self):
         super().__init__()
-        self.argparser.add_argument(
-            '--top1_thickness', action='store', type=float, default=1.5,
-            help=('thickness of the button hold layer, cherry like switches '
-                  'need 1.5mm or smaller to snap in')
-        )
-        self.argparser.add_argument(
-            '--top2_enable', action='store', type=boolarg, default=False,
-            help=('enables another top layer that can hold CPG151101S11 '
-                  'sockets')
-        )
-        self.argparser.add_argument(
-            '--top2_thickness', action='store', type=float, default=1.5,
-            help=('thickness of the hotplug layer, CPG151101S11 sockets '
-                  'need 1.2mm to 1.5mm')
-        )
-        self.addSettingsArgs(FingerJointSettings, surroundingspaces=1)
 
     def render(self):
-        """Renders the keypad."""
-        # deeper edge for top to add multiple layers
-        deep_edge = deepcopy(self.edges['f'].settings)
-        deep_edge.thickness = self.thickness + self.top1_thickness
-        if self.top2_enable:
-            deep_edge.thickness += self.top2_thickness
-        deep_edge.edgeObjects(self, 'gGH', True)
+        """Renders the keyboard."""
 
         self.moveTo(10, 30)
         case_x, case_y = self._case_x_y()
 
-        self.hole(0, 0, d=0.7)
+        margin = 2 * self.border + 1
 
         for reverse in [False, True]:
             # keyholder
             self.outer()
             self.half(reverse=reverse)
             self.holes()
-            self.moveTo(case_x + 13)
+            self.moveTo(case_x + margin)
 
             # support
             self.outer()
             self.half(self.support, reverse=reverse)
             self.holes()
-            self.moveTo(-case_x - 13, case_y + 13)
+            self.moveTo(-case_x - margin, case_y + margin)
 
             # hotplug
             self.outer()
             self.half(self.hotplug, reverse=reverse)
             self.holes()
-            self.moveTo(case_x + 13)
+            self.moveTo(case_x + margin)
 
             # border
             self.outer()
             self.rim()
             self.holes()
-            self.moveTo(-case_x - 13, case_y + 13)
+            self.moveTo(-case_x - margin, case_y + margin)
 
-
-    def holes(self):
+    def holes(self, diameter=3, margin=1.5):
         case_x, case_y = self._case_x_y()
-        self.hole(-1.5, -1.5, d=3)
-        self.hole(case_x + 1.5, -1.5, d=3)
-        self.hole(-1.5, case_y + 1.5, d=3)
-        self.hole(case_x + 1.5, case_y + 1.5, d=3)
+        for x in [-margin, case_x + margin]:
+            for y in [-margin, case_y + margin]:
+                self.hole(x, y, d=diameter)
 
     def micro(self):
         x = 17.9
@@ -94,7 +70,6 @@ class Atreus21(Boxes):
         )
 
     def rim(self):
-        s = 5
         x, y = self._case_x_y()
         self.moveTo(x * .5, y * .5)
         self.rectangularHole(0, 0, x, y, 5)
@@ -168,22 +143,6 @@ class Atreus21(Boxes):
         self.moveTo(0, self.btn_outer)
 
         self.set_source_color(Color.BLACK)
-
-    # stolen form electronics-box
-    def wallx_cb(self):
-        """Callback for triangle holes on x-side."""
-        x, _ = self._get_x_y()
-        t = self.thickness
-        self.fingerHolesAt(0, self.h - 1.5 * t, self.triangle, 0)
-        self.fingerHolesAt(x, self.h - 1.5 * t, self.triangle, 180)
-
-    # stolen form electronics-box
-    def wally_cb(self):
-        """Callback for triangle holes on y-side."""
-        _, y = self._get_x_y()
-        t = self.thickness
-        self.fingerHolesAt(0, self.h - 1.5 * t, self.triangle, 0)
-        self.fingerHolesAt(y, self.h - 1.5 * t, self.triangle, 180)
 
     # get case sizes
     def _case_x_y(self):

--- a/boxes/generators/atreus21.py
+++ b/boxes/generators/atreus21.py
@@ -4,13 +4,14 @@ from copy import deepcopy
 
 from boxes import Boxes, Color, holeCol, restore, boolarg
 from boxes.edges import FingerJointSettings
+from .keyboard import Keyboard
 
 
-class Atreus21(Boxes):
+class Atreus21(Boxes, Keyboard):
     """Generator for a split atreus keyboard."""
     ui_group = 'Misc'
     btn_size = 15.6
-    btn_outer = btn_size + 3.4
+    half_btn = btn_size / 2
     border = 6
 
     row_offsets=[3, 6, 11, 5, 0, btn_size * .5]
@@ -82,73 +83,36 @@ class Atreus21(Boxes):
         corner = [90, b]
         self.polyline(*([x, corner, y, corner] * 2))
         self.moveTo(0, b)
-    
-    def half(self, cb=None, reverse=False):
+
+    def half(self, hole_cb=None, reverse=False):
         row_offsets=self.row_offsets
         row_keys=self.row_keys
         scheme = list(zip(row_offsets, row_keys))
-        if reverse:
-            scheme.reverse()
-        for offset, keys in scheme:
-            self.moveTo(0, offset)
-            self.key_row(keys, cb)
-            self.moveTo(self.btn_outer)
-            self.moveTo(0, -offset)
-
-        total_moved_rows = len(row_offsets) * (self.btn_outer)
-        self.moveTo(total_moved_rows * -1, 0)
-
-    def key_row(self, n, hole_cb=None):
-        """Callback for the key holes."""
         if hole_cb == None:
             hole_cb = self.key
-        for _ in range(n):
-            hole_cb()
-        self.moveTo(0, -n * (self.btn_outer))
+        self.moveTo(self.half_btn, self.half_btn)
+        self.apply_callback_on_columns(
+            hole_cb,
+            scheme,
+            self.STANDARD_KEY_SPACING,
+            reverse,
+        )
+        self.moveTo(-self.half_btn, -self.half_btn)
 
     def support(self):
-        btn = [11.6, (-90, 2)] * 4
-        self.set_source_color(Color.BLUE)
-        self.moveTo(0, 2, 90)
-        self.polyline(*btn)
-        self.moveTo(-2, 0, 270)
-        self.moveTo(0, self.btn_outer)
-        self.set_source_color(Color.BLACK)
+        self.outer_hole()
 
     def hotplug(self):
-        self.moveTo(7.8 , 7.8)
-        self.hole(0, 0, d=4)
-        self.hole(1.27 * -3, 1.27 * 2, d=2.9)
-        self.hole(1.27 * 2, 1.27 * 4, d=2.9)
-
-        # pcb mounts
-        self.hole(1.27 * -4, 0, d=1.7)
-        self.hole(1.27 * 4, 0, d=1.7)
-
-        self.moveTo(-7.8, -7.8)
-        self.moveTo(0, self.btn_outer)
+        self.pcb_holes()
 
     def key(self):
-        self.set_source_color(Color.BLUE)
-
-        # draw clock wise to work with burn correction
-        btn_half_side = [0.98, 90, 0.81, -90, 3.5, -90, 0.81, 90, 2.505]
-        btn_full_side = [*btn_half_side, 0, *btn_half_side[::-1]]
-        btn = [*btn_full_side, -90] * 4
-
-        self.moveTo(0.81, 0.81, 90)
-        self.polyline(*btn)
-        self.moveTo(0, 0, 270)
-        self.moveTo(-0.81, -0.81)
-        self.moveTo(0, self.btn_outer)
-
-        self.set_source_color(Color.BLACK)
+        self.castle_shaped_plate_cutout()
 
     # get case sizes
     def _case_x_y(self):
-        x = len(self.row_offsets) * self.btn_outer - 4
+        x = len(self.row_offsets) * self.STANDARD_KEY_SPACING - 4
         y = sum([
-            max(self.row_keys) * self.btn_outer,  # total button sizes
+            max(self.row_keys) * self.STANDARD_KEY_SPACING,  # total button sizes
             max(self.row_offsets),  # offset of highest row
             -4,
         ])

--- a/boxes/generators/atreus21.py
+++ b/boxes/generators/atreus21.py
@@ -110,10 +110,11 @@ class Atreus21(Boxes, Keyboard):
 
     # get case sizes
     def _case_x_y(self):
-        x = len(self.row_offsets) * self.STANDARD_KEY_SPACING - 4
+        margin = self.STANDARD_KEY_SPACING - self.btn_size
+        x = len(self.row_offsets) * self.STANDARD_KEY_SPACING - margin
         y = sum([
             max(self.row_keys) * self.STANDARD_KEY_SPACING,  # total button sizes
             max(self.row_offsets),  # offset of highest row
-            -4,
+            -margin,
         ])
         return x, y

--- a/boxes/generators/keyboard.py
+++ b/boxes/generators/keyboard.py
@@ -73,11 +73,11 @@ class Keyboard:
         # draw clock wise to work with burn correction
         straight_edge = Keyboard.SWITCH_CASE_SIZE - 2 * radius
         polyline = [straight_edge, (-90, radius)] * 4
-        self.moveTo(0, radius, 90)
+        self.moveTo(self.burn, radius, 90)
         self.polyline(*polyline)
         self.moveTo(0, 0, 270)
         self.moveTo(0, -radius)
-        self.moveTo(0)
+        self.moveTo(-self.burn)
 
         if centered:
             self.moveTo(half_size, half_size)
@@ -96,10 +96,10 @@ class Keyboard:
         btn_full_side = [*btn_half_side, 0, *btn_half_side[::-1]]
         btn = [*btn_full_side, -90] * 4
 
-        self.moveTo(0.81, 0.81, 90)
+        self.moveTo(self.burn+0.81, 0.81, 90)
         self.polyline(*btn)
         self.moveTo(0, 0, 270)
-        self.moveTo(-0.81, -0.81)
+        self.moveTo(-self.burn-0.81, -0.81)
 
         if centered:
             self.moveTo(half_size, half_size)

--- a/boxes/generators/keyboard.py
+++ b/boxes/generators/keyboard.py
@@ -15,24 +15,133 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
+import argparse
+from boxes import Boxes, boolarg
 
 class Keyboard:
     """
     Code to manage Cherry MX compatible switches and Kailh hotswap socket.
+
+    Reference :
+    * https://www.cherrymx.de/en/dev.html
+    * https://cdn.sparkfun.com/datasheets/Components/Switches/MX%20Series.pdf
+    * https://www.kailhswitch.com/uploads/201815927/PG151101S11.pdf
     """
 
     STANDARD_KEY_SPACING = 19
     SWITCH_CASE_SIZE = 15.6
+    FRAME_CUTOUT = 14
 
     def __init__(self):
         pass
 
-    def pcb_holes(self):
+    def add_common_keyboard_parameters(
+        self,
+        add_hotswap_parameter=True,
+        add_pcb_mount_parameter=True,
+        add_led_parameter=True,
+        add_diode_parameter=True,
+        add_cutout_type_parameter=True,
+        default_columns_definition=None,
+    ):
+        if add_hotswap_parameter:
+            self.argparser.add_argument(
+                "--hotswap_enable",
+                action="store",
+                type=boolarg,
+                default=True,
+                help=("enlarge switches holes for hotswap pcb sockets"),
+            )
+        if add_pcb_mount_parameter:
+            self.argparser.add_argument(
+                "--pcb_mount_enable",
+                action="store",
+                type=boolarg,
+                default=True,
+                help=("adds holes for pcb mount switches"),
+            )
+        if add_led_parameter:
+            self.argparser.add_argument(
+                "--led_enable",
+                action="store",
+                type=boolarg,
+                default=False,
+                help=("adds pin holes under switches for leds"),
+            )
+        if add_diode_parameter:
+            self.argparser.add_argument(
+                "--diode_enable",
+                action="store",
+                type=boolarg,
+                default=False,
+                help=("adds pin holes under switches for diodes"),
+            )
+        if add_cutout_type_parameter:
+            self.argparser.add_argument(
+                "--cutout_type",
+                action="store",
+                type=str,
+                default="castle",
+                help=(
+                    "Shape of the plate cutout: 'castle' allows for modding, and 'simple' is a tighter and simpler square"
+                ),
+            )
+        if default_columns_definition:
+            self.argparser.add_argument(
+            "--columns_definition",
+                type=self.argparseColumnsDefinition,
+                default=default_columns_definition,
+                help=(
+                    "Each column is separated by '/', and is in the form 'nb_rows @ offset x repeat_count'. "
+                    "Nb_rows is the number of rows for this column. "
+                    "The offset is in mm and optional. "
+                    "Repeat_count is optional and repeats this column multiple times. "
+                    "Spaces are not important."
+                    "For example '3x2 / 4@11' means we want 3 columns, the two first with "
+                    "3 rows without offset, and the last with 4 rows starting at 11mm high."
+                ),
+            )
+
+    def argparseColumnsDefinition(self, s):
+        """
+        Parse columns definition parameter
+
+        :param s: string to parse
+
+        Each column is separated by '/', and is in the form 'nb_rows @ offset x repeat_count'.
+        Nb_rows is the number of rows for this column.
+        The offset is in mm and optional.
+        Repeat_count is optional and repeats this column multiple times.
+        Spaces are not important.
+        For example '3x2 / 4@11' means we want 3 columns, the two first with
+        3 rows without offset, and the last with 4 rows starting at 11mm high
+
+        """
+        result = []
+        try:
+            for column_string in s.split("/"):
+                m = re.match(r"^\s*(\d+)\s*@?\s*(\d*\.?\d*)(?:\s*x\s*(\d+))?\s*$", column_string)
+                keys_count = int(m.group(1))
+                offset = float(m.group(2)) if m.group(2) else 0
+                n = int(m.group(3)) if m.group(3) else 1
+                result.extend([(offset, keys_count)]*n)
+        except:
+            raise argparse.ArgumentTypeError("Don't understand columns definition string")
+
+        return result
+
+    def pcb_holes(
+        self, with_hotswap=True, with_pcb_mount=True, with_led=False, with_diode=False
+    ):
         grid_unit = 1.27
         main_hole_size = 4
         pcb_mount_size = 1.7
         led_hole_size = 1
-        pin_hole_size = 2.9
+        if with_hotswap:
+            pin_hole_size = 2.9
+        else:
+            pin_hole_size = 1.5
 
         def grid_hole(x, y, d):
             self.hole(grid_unit * x, grid_unit * y, d=d)
@@ -44,8 +153,17 @@ class Keyboard:
         grid_hole(-3, 2, pin_hole_size)
         grid_hole(2, 4, pin_hole_size)
 
-        grid_hole(-4, 0, pcb_mount_size)
-        grid_hole(4, 0, pcb_mount_size)
+        if with_pcb_mount:
+            grid_hole(-4, 0, pcb_mount_size)
+            grid_hole(4, 0, pcb_mount_size)
+
+        if with_led:
+            grid_hole(-1, -4, led_hole_size)
+            grid_hole(1, -4, led_hole_size)
+
+        if with_diode:
+            grid_hole(-3, -4, led_hole_size)
+            grid_hole(3, -4, led_hole_size)
 
     def apply_callback_on_columns(self, cb, columns_definition, spacing, reverse=False):
         if reverse:
@@ -103,3 +221,63 @@ class Keyboard:
 
         if centered:
             self.moveTo(half_size, half_size)
+
+    def configured_plate_cutout(self, support=False):
+        """
+        Choose which cutout to use based on configured type.
+
+        support: if true, not the main cutout, but one to glue against the first
+        1.5mm cutout to strengthen it, without the clipping part.
+        """
+        if self.cutout_type.lower() == "castle":
+            if support:
+                self.outer_hole()
+            else:
+                self.castle_shaped_plate_cutout()
+        else:
+            self.simple_plate_cutout(with_notch=support)
+
+    def simple_plate_cutout(self, radius=0.2, with_notch=False):
+        """
+        A simple plate cutout, a 14mm rectangle, as specified in this reference sheet
+        https://cdn.sparkfun.com/datasheets/Components/Switches/MX%20Series.pdf
+
+        With_notch shoul be used for a secondary lower plate, strengthening the first one.
+        A notch is added to let the hooks grasp the main upper plate.
+
+        Current position should be switch center.
+
+        Radius should be lower or equal to 0.3 mm
+        """
+        size = Keyboard.FRAME_CUTOUT
+        half_size = size / 2
+
+        if with_notch:
+            notch_length = 5
+            notch_depth = 1
+            straight_part = 0.5 * (size - 2 * radius - 2 * notch_depth - notch_length)
+
+            self.moveTo(-half_size + self.burn, 0, 90)
+            polyline_quarter = [
+                half_size - radius,
+                (-90, radius),
+                straight_part,
+                (90, notch_depth / 2),
+                0,
+                (-90, notch_depth / 2),
+                notch_length / 2,
+            ]
+            polyline = (
+                polyline_quarter
+                + [0]
+                + list(reversed(polyline_quarter))
+                + [0]
+                + polyline_quarter
+                + [0]
+                + list(reversed(polyline_quarter))
+            )
+            self.polyline(*polyline)
+            self.moveTo(0, 0, -90)
+            self.moveTo(half_size - self.burn)
+        else:
+            self.rectangularHole(0, 0, size, size, r=radius)

--- a/boxes/generators/keyboard.py
+++ b/boxes/generators/keyboard.py
@@ -165,7 +165,9 @@ class Keyboard:
             grid_hole(-3, -4, led_hole_size)
             grid_hole(3, -4, led_hole_size)
 
-    def apply_callback_on_columns(self, cb, columns_definition, spacing, reverse=False):
+    def apply_callback_on_columns(self, cb, columns_definition, spacing=None, reverse=False):
+        if spacing == None:
+            spacing = self.STANDARD_KEY_SPACING
         if reverse:
             columns_definition = list(reversed(columns_definition))
 

--- a/boxes/generators/keyboard.py
+++ b/boxes/generators/keyboard.py
@@ -29,7 +29,7 @@ class Keyboard:
     * https://www.kailhswitch.com/uploads/201815927/PG151101S11.pdf
     """
 
-    STANDARD_KEY_SPACING = 19
+    STANDARD_KEY_SPACING = 19.05
     SWITCH_CASE_SIZE = 15.6
     FRAME_CUTOUT = 14
 

--- a/boxes/generators/keyboard.py
+++ b/boxes/generators/keyboard.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021 Guillaume Collic
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class Keyboard:
+    """
+    Code to manage Cherry MX compatible switches and Kailh hotswap socket.
+    """
+
+    STANDARD_KEY_SPACING = 19
+    SWITCH_CASE_SIZE = 15.6
+
+    def __init__(self):
+        pass
+
+    def pcb_holes(self):
+        grid_unit = 1.27
+        main_hole_size = 4
+        pcb_mount_size = 1.7
+        led_hole_size = 1
+        pin_hole_size = 2.9
+
+        def grid_hole(x, y, d):
+            self.hole(grid_unit * x, grid_unit * y, d=d)
+
+        # main hole
+        grid_hole(0, 0, main_hole_size)
+
+        # switch pins
+        grid_hole(-3, 2, pin_hole_size)
+        grid_hole(2, 4, pin_hole_size)
+
+        grid_hole(-4, 0, pcb_mount_size)
+        grid_hole(4, 0, pcb_mount_size)
+
+    def apply_callback_on_columns(self, cb, columns_definition, spacing, reverse=False):
+        if reverse:
+            columns_definition = list(reversed(columns_definition))
+
+        for offset, nb_keys in columns_definition:
+            self.moveTo(0, offset)
+            for _ in range(nb_keys):
+                cb()
+                self.moveTo(0, spacing)
+            self.moveTo(spacing, -nb_keys * spacing)
+            self.moveTo(0, -offset)
+
+        total_width = len(columns_definition) * spacing
+        self.moveTo(-1 * total_width)
+
+    def outer_hole(self, radius=2, centered=True):
+        """
+        Draws a rounded square big enough to go around a whole switch (15.6mm)
+        """
+        half_size = Keyboard.SWITCH_CASE_SIZE / 2
+        if centered:
+            self.moveTo(-half_size, -half_size)
+
+        # draw clock wise to work with burn correction
+        straight_edge = Keyboard.SWITCH_CASE_SIZE - 2 * radius
+        polyline = [straight_edge, (-90, radius)] * 4
+        self.moveTo(0, radius, 90)
+        self.polyline(*polyline)
+        self.moveTo(0, 0, 270)
+        self.moveTo(0, -radius)
+        self.moveTo(0)
+
+        if centered:
+            self.moveTo(half_size, half_size)
+
+    def castle_shaped_plate_cutout(self, centered=True):
+        """
+        This cutout shaped like a castle enables switch modding and rotation.
+        More information (type 4) on https://geekhack.org/index.php?topic=59837.0
+        """
+        half_size = Keyboard.SWITCH_CASE_SIZE / 2
+        if centered:
+            self.moveTo(-half_size, -half_size)
+
+        # draw clock wise to work with burn correction
+        btn_half_side = [0.98, 90, 0.81, -90, 3.5, -90, 0.81, 90, 2.505]
+        btn_full_side = [*btn_half_side, 0, *btn_half_side[::-1]]
+        btn = [*btn_full_side, -90] * 4
+
+        self.moveTo(0.81, 0.81, 90)
+        self.polyline(*btn)
+        self.moveTo(0, 0, 270)
+        self.moveTo(-0.81, -0.81)
+
+        if centered:
+            self.moveTo(half_size, half_size)


### PR DESCRIPTION
I'm planning to update [my custom keyboard](https://github.com/gcollic/grimoire60_keyboard). I'm doing some test, and obviously I'm using boxes.py this time.

My keyboard is not ready to share, but in preparation I already updated the `atreus21` and `keypad` "boxes" for better reuse, uniformity, and options.

I did the following changes:

- there was duplication
    - I created a Keyboard class to share keyboard specific functionnalities
    - keypad profits from the code structure of atreus
- `atreus`'s layout was not configurable (but the code was already parameterized), and `keypad`'s layout options were very limited
    - I created a unified arg parser (inspired by `argparseSections`)
    - the default value gives the same result as before
    - both boxes can now generate a lot of different layouts
- the values used were not documented
    - I added references to switches and socket specification sheets
    - I named some values
- there was dead code
    - I removed some code, generally copied from each other
- I fixed a slight bug in both
    - One of the layer was slightly off and assymetrical (missing a move by the length of the burn value)
    - ![image](https://user-images.githubusercontent.com/763200/107863713-d1bd0280-6e56-11eb-8e0a-f447090d4d04.png)
- The "PCB" holes were not configurable
    - now it supports all the different Cherry MX options I know:
    - ![image](https://user-images.githubusercontent.com/763200/107863316-ba304a80-6e53-11eb-9935-13ab4fee233f.png)
    - it now also supports to enable/disable the larger pin hole in case of hotswap socket
- A new switch cutout option
    - I prefer the tighter official cutout than the one used by default on these project
    - but the tighter version doesn't allow to "mod" the switch afterwards, so both options are still useful
    - ![image](https://user-images.githubusercontent.com/763200/107863556-aa196a80-6e55-11eb-8062-00f606af11d5.png)
-  The new settings are shared between keyboard project
    - with opt in / opt out

My changes are compatible with the previous version, except for the deleted `keypad.btn_x` and `keypad.btn_y` settings which were replaced by `keypad.columns_definition`. The explicit `4x3` value and the default value still give the same result as the old default `btn_x=3` and `btn_y=4`.

I would like to add a `keyboard` category some day, but right now there is still only 2 keyboard projects (one in "Box" and one in "Misc") so it's probably better to wait for a third one to have a category for them.