### PR TITLE
Fix Boxes.saved_context example in Navigation documentation

### DIFF
--- a/documentation/src/api_navigation.rst
+++ b/documentation/src/api_navigation.rst
@@ -26,7 +26,7 @@ It can be used with the following code pattern:
 
 .. code-block:: python
 
-   with self.saved_context:
+   with self.saved_context():
        self.rectangularWall(x, h, move="right")
        self.rectangularWall(y, h, move="right")
        self.rectangularWall(y, h, move="right")


### PR DESCRIPTION
The code example for Boxes.saved_context() uses a with statement
that does not properly call the self.saved_context method (misses
call parenthesis).