### PR TITLE
Parametrizise the drillbox

### DIFF
--- a/boxes/Color.py
+++ b/boxes/Color.py
@@ -4,3 +4,9 @@ class Color:
     GREEN = [ 0.0, 1.0, 0.0 ]
     RED   = [ 1.0, 0.0, 0.0 ]
     WHITE = [ 1.0, 1.0, 1.0 ]
+
+    # TODO: Make this configurable
+    OUTER_CUT = BLACK
+    INNER_CUT = BLUE
+    ANNOTATIONS = RED
+    ETCHING = GREEN

--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -72,9 +72,14 @@ def holeCol(func):
 
     @wraps(func)
     def f(self, *args, **kw):
+        if "color" in kw:
+            color = kw.pop("color")
+        else:
+            color = Color.INNER_CUT
+
         self.ctx.stroke()
         with self.saved_context():
-            self.set_source_color(Color.BLUE)
+            self.set_source_color(color)
             func(self, *args, **kw)
             self.ctx.stroke()
 

--- a/boxes/generators/drillbox.py
+++ b/boxes/generators/drillbox.py
@@ -66,8 +66,7 @@ class DrillBox(Boxes):
                 for k in range(self.holes):
                     self.hole(x + dx / 2, y + (k + 0.5) * iy, d + 0.05)
                 if description:
-                    self.rectangularHole(x + dx / 2, y + dy / 2, dx - 2, dy - 2)
-                    # TODO: make the "hole" green to indicate etching
+                    self.rectangularHole(x + dx / 2, y + dy / 2, dx - 2, dy - 2, color=Color.ETCHING)
                     self.text(
                         "%.1f" % d,
                         x + 2,
@@ -75,7 +74,7 @@ class DrillBox(Boxes):
                         270,
                         align="right",
                         fontsize=6,
-                        color=Color.GREEN,
+                        color=Color.ETCHING,
                     )
                     # TODO: make the fontsize dynamic to make the text fit in all cases
                 d += self.holeincrement

--- a/documentation/src/usermanual.rst
+++ b/documentation/src/usermanual.rst
@@ -147,3 +147,20 @@ settings to the user. In the web interface they are folded up. In the
 command line interfacce they are grouped together. Users should be
 aware that not all settings are practical to change. For now Boxes.py
 does not allow hiding some settings.
+
+Colors
+------
+The generated files uses the following color conventions:
+
+.. glossary::
+     Black 
+        The outer edges of a part
+     Blue
+        Inner edges of a part
+     Red
+        Comments or help lines that are not ment to be cut or etched
+     Green
+        Etchings
+
+Normaly you will cut things in the order: Green, Blue, Black. If other 
+colors are present, the meaning should hopefully be obvious.


### PR DESCRIPTION
Adds the parameters: sx, xy, h, holes, firsthole and holeincrement.

It adds two TODOs: 
One needs changes in the Boxes-class and should be in a separate pull request (changing color of the etched boxes) and one that i have not worked out how to do yet (dynamic text). I could try to include them here if you want.

My editor tends to use [black](https://black.readthedocs.io/en/stable/index.html)  to format the code as default and since I could not find any preference for what codestyle to use I kept it on all changed lines (which is more or less everything :-). If you prefer any other style, just say and I will create a new patch in that style.
