### PR TITLE
cask is no longer a brew command

### DIFF
--- a/documentation/src/install/macos.rst
+++ b/documentation/src/install/macos.rst
@@ -65,7 +65,7 @@ are required:
 
    .. code::
 
-      brew cask install inkscape
+      brew install inkscape
 
 2. From the root directory of the repository, run:
 


### PR DESCRIPTION
### The issue

When installing Inkscape and the boxes.py extensions on macOS BigSur 11.6 using the procedure described in the documentation I encountered an error : 
`Error: Unknown command: cask`.

After a bit of research, it appears that `cask` is no longer needed to use brew, and `brew install inkscape` is now the way to go, and Inkscape got installed indeed.

### How to reproduce the bug
Try installing Inkscape with `brew cask install inkscape` as per the documentation.

### Fix
Use `brew install inkscape` instead

### Sources
The Homebrew discussion on its Github repo from which I gathered the information : https://github.com/Homebrew/discussions/discussions/902