### PR TITLE
Feat/divider tray outside walls finger notches

### DIFF
--- a/boxes/generators/dividertray.py
+++ b/boxes/generators/dividertray.py
@@ -188,8 +188,6 @@ class DividerTray(Boxes):
             second_tab_width=self.thickness if self.right_wall else 0
         )
         for i, length in enumerate(self.sx):
-            is_first_wall = i == 0
-            is_last_wall = i == len(self.sx) - 1
             self.generate_divider(
                 [length],
                 divider_height,


### PR DESCRIPTION
Nearly every time I'm using the DividerTray I contributed, I end up adding the same notches in the walls than the dividers, to help catch the content, so here is this modification.

From my experience it should be the default, but I can live with it being opt-in ;-)

I'm not really fond of this new edge object not using the actual length received in parameter. I could adjust the "sx" in case there is a mismatch, but there is no call to this edge needing to add this code for now. Do you have an opinion on this?

Thank you!