### PR TITLE
feat: DividerTray make the play optional

### DIFF
--- a/boxes/generators/dividertray.py
+++ b/boxes/generators/dividertray.py
@@ -83,6 +83,12 @@ class DividerTray(Boxes):
             help="divider's notch's depth",
         )
         self.argparser.add_argument(
+            "--divider_play",
+            type=float,
+            default=0.15,
+            help="divider's play to avoid them clamping onto the walls",
+        )
+        self.argparser.add_argument(
             "--left_wall",
             type=boolarg,
             default=True,
@@ -264,8 +270,7 @@ class DividerTray(Boxes):
             return
 
         # Upper edge with a finger notch
-
-        play = 0.05 * self.thickness
+        play = self.divider_play
 
         # Upper: first tab width
         self.edge(first_tab_width - play)


### PR DESCRIPTION
The new features on the DividerTray are great, thank you ^^

There is now a play for easier divider insertion and removal, but in my case the lack of play was intentional and can help structural integrity with longer box insert made from more flexible wood (the dividers are rarely moved), so I propose to make the play optionnal.