### PR TITLE
fixed error generating an empty path list

### DIFF
--- a/boxes/drawing.py
+++ b/boxes/drawing.py
@@ -150,8 +150,10 @@ class Path:
     def __repr__(self):
         l = len(self.path)
         # x1,y1 = self.path[0][1:3]
-        x2, y2 = self.path[-1][1:3]
-        return f"Path[{l}] to ({x2:.2f},{y2:.2f})"
+        if l>0:
+            x2, y2 = self.path[-1][1:3]
+            return f"Path[{l}] to ({x2:.2f},{y2:.2f})"
+        return f"empty Path"
 
     def extents(self):
         e = Extents()
@@ -208,7 +210,8 @@ class Path:
                         else:
                             self.path[i] =  ("L", x, y)
         # filter duplicates
-        self.path = [p for n, p in enumerate(self.path) if p != self.path[n-1]]
+        if len(self.path) > 1: # no need to find duplicates if only one element in path
+            self.path = [p for n, p in enumerate(self.path) if p != self.path[n-1]]
 
 class Context:
     def __init__(self, surface, *al, **ad):
@@ -759,14 +762,13 @@ class LBRN2Surface(Surface):
                 path.faster_edges(inner_corners)
                 num = 0
                 cnt = 1
-                
                 ende = len(path.path)-1
                 if self.dbg: 
                     for c in path.path:
                         print ("6",num, c)
                         num += 1
+                    num = 0
                     
-                num = 0
                 c = path.path[num]
                 C, x, y = c[0:3]
                 if self.dbg: print("ende:" ,ende)


### PR DESCRIPTION
Found an error which broke lbrn2 output.

In function _faster_edges(self, inner_corners)_ the duplicate removal fails if there is only one element in the path list. This single element gets removed in any case, which results in an empty path list, which in turn will crash the lbrn2 output.

Furthermore trying to output an empty list via print also results in an error which costs me some time at debugging...

This patch deals with both issues.

Cheers
  Klaus
 