### PR TITLE
Dicebox

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -1231,7 +1231,7 @@ class Boxes:
 
     @restore
     @holeCol
-    def regularPolygonHole(self, x, y, r=0.0, d=0.0, n=6, a=0.0, tabs=0):
+    def regularPolygonHole(self, x, y, r=0.0, d=0.0, n=6, a=0.0, tabs=0, corner_radius=0.0):
         """
         Draw a hole in shape of an n-edged regular polygon
 
@@ -1249,15 +1249,30 @@ class Boxes:
         if n == 0:
             self.hole(x, y, r=r, tabs=tabs)
             return
+ 
         if r < self.burn:
             r = self.burn + 1E-9
         r_ = r - self.burn
+        
+        if corner_radius < self.burn:
+            corner_radius = self.burn
+        cr_ = corner_radius - self.burn
+
+        side_length = 2 * r_ * math.sin(math.pi / n)
+        apothem = r_ * math.cos(math.pi / n)
+        # the corner chord:
+        s = math.sqrt(2 * math.pow(cr_, 2) * (1 - math.cos(2 * math.pi / n)))
+        # the missing portion of the rounded corner:
+        b = math.sin(math.pi / n) / math.sin(2 * math.pi / n) * s
+        # the flat portion of the side:
+        flat_side_length = side_length - 2 * b
+        
         self.moveTo(x, y, a)
         self.moveTo(r_, 0, 90+180/n)
-        l = 2 * r_ * math.sin(math.pi / n)
-        for i in range(n):
-            self.edge(l)
-            self.corner(360/n)
+        self.moveTo(b, 0, 0)
+        for _ in range(n):
+            self.edge(flat_side_length)
+            self.corner(360/n, cr_)
 
     @restore
     @holeCol

--- a/boxes/generators/dicebox.py
+++ b/boxes/generators/dicebox.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (C) 2022 Erik Snider (SniderThanYou@gmail.com)
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from boxes import *
+
+
+class DiceBox(Boxes):
+    """Box with lid and integraded hinge for storing dice"""
+
+    ui_group = "Misc"
+
+    def __init__(self):
+        Boxes.__init__(self)
+        self.addSettingsArgs(
+            edges.FingerJointSettings,
+            surroundingspaces=2.0)
+        self.addSettingsArgs(
+            edges.ChestHingeSettings,
+            finger_joints_on_box=True,
+            finger_joints_on_lid=True)
+        self.buildArgParser(
+            x=100,
+            y=100,
+            h=18,
+            outside=True)
+        self.argparser.add_argument(
+            "--lidheight",  action="store", type=float, default=18,
+            help="height of lid in mm")
+        self.argparser.add_argument(
+            "--hex_hole_corner_radius",  action="store", type=float, default=5,
+            help="The corner radius of the hexagonal dice holes, in mm")
+        self.argparser.add_argument(
+            "--magnet_diameter",  action="store", type=float, default=6,
+            help="The diameter of magnets for holding the box closed, in mm")
+
+    def diceCB(self):
+        t = self.thickness
+        xi = self.x - 2 * t
+        yi = self.y - 2 * t
+        xc = xi / 2
+        yc = yi / 2
+        cr = self.hex_hole_corner_radius
+
+        # -4*t because there are four gaps across:
+        #   2 between the outer holes and the finger joints
+        #   2 between the outer holes and the center hole
+        # /6 because there are 6 apothems across, 2 for each hexagon
+        apothem = (min(xi, yi) - 4 * t) / 6
+        r = apothem * 2 / math.sqrt(3)
+
+        # dice
+        centers = [[xc, yc]]  # start with one in the center
+        polar_r = 2 * apothem + t  # the full width of a hexagon, plus a gap of t width
+        for i in range(6):
+            theta = i * math.pi / 3  # 60 degrees each step
+            centers.append(
+                [
+                    xc + polar_r * math.cos(theta),
+                    yc + polar_r * math.sin(theta),
+                ]
+            )
+        for center in centers:
+            self.regularPolygonHole(x=center[0], y=center[1], n=6, r=r, corner_radius=cr, a=30)
+
+        # magnets
+        d = self.magnet_diameter
+        mo = t + d/2
+        self.hole(mo, mo, d=d)
+        self.hole(xi-mo, mo, d=d)
+
+    def render(self):
+        x, y, h, hl = self.x, self.y, self.h, self.lidheight
+
+        if self.outside:
+            x = self.adjustSize(x)
+            y = self.adjustSize(y)
+            h = self.adjustSize(h)
+            hl = self.adjustSize(hl)
+
+        t = self.thickness
+
+        hy = self.edges["O"].startwidth()
+        hy2 = self.edges["P"].startwidth()
+
+        e1 = edges.CompoundEdge(self, "eF", (hy-t, h-hy+t))
+        e2 = edges.CompoundEdge(self, "Fe", (h-hy+t, hy-t))
+        e_back = ("F", e1, "F", e2)
+
+        p = self.edges["o"].settings.pin_height
+        e_inner_1 = edges.CompoundEdge(self, "fe", (y-p, p))
+        e_inner_2 = edges.CompoundEdge(self, "ef", (p, y-p))
+        e_inner_topbot = ("f", e_inner_1, "f", e_inner_2)
+
+        self.ctx.save()
+
+        self.rectangularWall(x, y, e_inner_topbot, move="up", callback=[self.diceCB])
+        self.rectangularWall(x, y, e_inner_topbot, move="up", callback=[self.diceCB])
+        self.rectangularWall(x, h, "FFFF", ignore_widths=[1,2,5,6], move="up")
+        self.rectangularWall(x, h, e_back, move="up")
+        self.rectangularWall(x, hl, "FFFF", ignore_widths=[1,2,5,6], move="up")
+        self.rectangularWall(x, hl-hy2+t, "FFqF", move="up")
+
+        self.ctx.restore()
+        self.rectangularWall(x, y, "ffff", move="right only")
+
+        self.rectangularWall(y, x, "ffff", move="up")
+        self.rectangularWall(y, x, "ffff", move="up")
+        self.rectangularWall(y, hl-hy2+t, "Ffpf", ignore_widths=[5,6], move="up")
+        self.rectangularWall(y, h-hy+t, "OfFf", ignore_widths=[5,6], move="up")
+        self.rectangularWall(y, h-hy+t, "Ffof", ignore_widths=[5,6], move="up")
+        self.rectangularWall(y, hl-hy2+t, "PfFf", ignore_widths=[5,6], move="up")


### PR DESCRIPTION
This PR adds a new generator for a dice box. It is based on the `IntegratedHingeBox`, but requires some extra finger joints for the dice separator panels. I added the finger joint support to three of the `ChestHingeXYZ` edges. If there's a better way to do it, please let me know.

I also updated `regularPolygonHole()` to support rounded corners, because it just looks a little nicer than the sharp corners. I used the `FillTest` generator to verify that the existing functionality is preserved. `FillTest` uses `fillHoles()`, which uses `regularPolygonHole()`

![PXL_20220810_021014702](https://user-images.githubusercontent.com/1890082/183988356-851145f4-1133-4c1d-b823-937976801966.jpg)