### PR TITLE
Fix processing of grip_percentage parameter

### DIFF
--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -1482,7 +1482,7 @@ class HingePin(BaseEdge):
 
     def __call__(self, l, **kw):
         plen = getattr(self, self.settings.style + 'len', self.outsetlen)()
-        glen = l * self.settings.grip_percentage + \
+        glen = l * self.settings.grip_percentage / 100 + \
                self.settings.grip_length
 
         if not self.settings.outset:


### PR DESCRIPTION
grip_percentage is initialized with integer zero value but was not divided by 100 when used.
In this small patch division by 100 is added