### PR TITLE
Add edges to polygonWall

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -219,7 +219,7 @@ class BoolArg:
             default = self(default)
         return """<input name="%s" type="hidden" value="0">
 <input name="%s" id="%s" aria-labeledby="%s %s" type="checkbox" value="1"%s>""" % \
-            (name, name, name, name+"_id", name+"_description",' checked="checked"' if default else "") 
+            (name, name, name, name+"_id", name+"_description",' checked="checked"' if default else "")
 
 boolarg = BoolArg()
 
@@ -1182,7 +1182,7 @@ class Boxes:
             self.ctx.restore()
             if self.labels and label:
                 self.text(label, x/2, y/2, align="middle center", color=Color.ANNOTATIONS, fontsize=4)
-            self.ctx.stroke() 
+            self.ctx.stroke()
 
         for term in terms:
             if not term in moves:
@@ -1252,11 +1252,11 @@ class Boxes:
         if n == 0:
             self.hole(x, y, r=r, tabs=tabs)
             return
- 
+
         if r < self.burn:
             r = self.burn + 1E-9
         r_ = r - self.burn
-        
+
         if corner_radius < self.burn:
             corner_radius = self.burn
         cr_ = corner_radius - self.burn
@@ -1269,7 +1269,7 @@ class Boxes:
         b = math.sin(math.pi / n) / math.sin(2 * math.pi / n) * s
         # the flat portion of the side:
         flat_side_length = side_length - 2 * b
-        
+
         self.moveTo(x, y, a)
         self.moveTo(r_, 0, 90+180/n)
         self.moveTo(b, 0, 0)
@@ -1404,17 +1404,17 @@ class Boxes:
         :param angle: rotation angle of the hole
 
         """
-        
+
         if d_shaft < (2 * self.burn):
             return  # no hole if diameter is smaller then the capabilities of the machine
-        
+
         if not d_head or d_head < (2 * self.burn): # if no head diameter is given
             self.hole(x, y ,d=d_shaft, tabs=tabs)  # only a round hole is generated
             return
-            
+
         rs = d_shaft / 2
         rh = d_head / 2
-        
+
         self.moveTo(x, y, angle)
         self.moveTo(0, rs - self.burn, 0)
         self.corner(-180, rs, tabs)
@@ -1713,7 +1713,7 @@ class Boxes:
             if self.debug:
                 self.showBorderPoly(list(outerCutPoly.exterior.coords))
                 self.showBorderPoly(list(innerCutPoly.exterior.coords))
-            
+
             # set startpoint
             y = min_y + bspace + max_radius_y
 
@@ -2415,7 +2415,7 @@ class Boxes:
         :param r: radius of the corners of the flange
         :param callback:  (Default value = None)
         :param move:  (Default value = None)
-        :param label: rendered to identify parts, it is not ment to be cut or etched (Default value = "")        
+        :param label: rendered to identify parts, it is not ment to be cut or etched (Default value = "")
         """
 
         t = self.thickness
@@ -2475,7 +2475,7 @@ class Boxes:
         :param bedBoltSettings:  (Default value = None)
         :param callback:  (Default value = None)
         :param move:  (Default value = None)
-        :param label: rendered to identify parts, it is not ment to be cut or etched (Default value = "")    
+        :param label: rendered to identify parts, it is not ment to be cut or etched (Default value = "")
         """
         edges = [self.edges.get(e, e) for e in edges]
         if len(edges) == 2:

--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -2692,12 +2692,26 @@ class Boxes:
         return ext
 
     def polygonWall(self, borders, edge="f", turtle=False,
-                    callback=None, move=None):
+                    callback=None, move=None, label=""):
+        """
+        Polygon wall for all kind of multi-edged objects
 
-        e = self.edges.get(edge, edge)
+        :param borders: array of distance and angles to draw
+        :param edge:  (Default value = "f") Edges to apply. If the array of borders contains more segments that edges, the edge will wrap. Only edge types without start and end width suppported for now.
+        :param turtle: (Default value = False)
+        :param callback:  (Default value = None)
+        :param move:  (Default value = None)
+        :param label: rendered to identify parts, it is not ment to be cut or etched (Default value = "")
+
+        """
+        try:
+            edges = [self.edges.get(e, e) for e in edge]
+        except TypeError:
+            edges = [self.edges.get(edge, edge)]
+
         t = self.thickness # XXX edge.margin()
 
-        minx, miny, maxx, maxy = self._polygonWallExtend(borders, e)
+        minx, miny, maxx, maxy = self._polygonWallExtend(borders, edges[0])
 
         tw, th = maxx - minx, maxy - miny
 
@@ -2719,12 +2733,13 @@ class Boxes:
             else:
                 length_correction = 0.0
             l -= length_correction
-            e(l)
+            edge = edges[(i//2)%len(edges)]
+            edge(l)
             self.edge(length_correction)
             self.corner(next_angle, tabs=1)
 
         if not turtle:
-            self.move(tw, th, move)
+            self.move(tw, th, move, label=label)
 
     @restore
     def polygonWalls(self, borders, h, bottom="F", top="F", symetrical=True):

--- a/documentation/src/api_existing_parts.rst
+++ b/documentation/src/api_existing_parts.rst
@@ -11,6 +11,7 @@ Currently there are the following parts:
 .. automethod:: boxes.Boxes.flangedWall
 .. automethod:: boxes.Boxes.rectangularTriangle
 .. automethod:: boxes.Boxes.regularPolygonWall
+.. automethod:: boxes.Boxes.polygonWall
 .. automethod:: boxes.Boxes.roundedPlate
 .. automethod:: boxes.Boxes.surroundingWall
 


### PR DESCRIPTION
Fixes #459 by allowing multiple edge definitions for polygonWall.  Also added function documentation to polygonWall.

The call on line 2710 to _polygonWallExtend may need additional comments since it does not account for multiple edge types.  I'm not entirely sure how to use those to calculate the extents of the shape.

I did spot check the output of console and heart to confirm that this change did not introduce a regression error, but did not attempt multiple variations.  I didn't see any automatic tests, but let me know if there are any e2e or snapshot tests that could be run to confirm behavior.