### PR TITLE
Remove support of EOL Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     author_email='florian@festi.info',
     url='https://github.com/florianfesti/boxes',
     packages=find_packages(),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=['affine>=2.0', 'markdown', 'shapely>=1.8.2'],
     scripts=['scripts/boxes', 'scripts/boxesserver'],
     cmdclass={


### PR DESCRIPTION
Python 3.6 reached end of life 2021-12-23.
https://devguide.python.org/versions/

## Reference

fixes #471