### PR TITLE
Rename `ps2edit` to more common `pstoedit`

### DIFF
--- a/documentation/src/install.rst
+++ b/documentation/src/install.rst
@@ -33,12 +33,12 @@ Setup.py uses the :code:`setuptools` library (package name may be
 :code:`python*-setuptools`). You only need it if you want to build the
 package.
 
-ps2edit
+pstoedit
 .......
 
-While not a hard requirement Boxes.py uses :code:`ps2edit` to offer formats
+While not a hard requirement Boxes.py uses :code:`pstoedit` (sometimes :code:`ps2edit`) to offer formats
 that are not supported by Cairo: DXF, gcode, PLT. Currently the location
-Boxes.py looks for :code:`ps2edit` is hard coded to :code:`/usr/bin/pstoedit`
+Boxes.py looks for :code:`pstoedit` is hard coded to :code:`/usr/bin/pstoedit`
 in the :code:`boxes.formats.Formats` class.
 
 Python

--- a/documentation/src/usermanual.rst
+++ b/documentation/src/usermanual.rst
@@ -91,7 +91,7 @@ format
 ......
 
 Boxes.py is able to create multiple formats. For most of them it
-requires ``ps2edit``. Without ``ps2edit`` only ``SVG``
+requires ``pstoedit``. Without ``pstoedit`` only ``SVG``
 and ``postscript`` (ps) is supported. Otherwise you can also
 select
 
@@ -101,7 +101,7 @@ select
 * pdf
 * plt
 
-Other formats supported by ``ps2edit`` can be added easily. Please
+Other formats supported by ``pstoedit`` can be added easily. Please
 open a ticket on GitHub if you need one.
 
 tabs


### PR DESCRIPTION
After some research it seems that `ps2edit` was only used in some releases and `pstoedit` is the common spelling.