### PR TITLE
Fix boxesserver

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -17,7 +17,10 @@ FROM fedora:latest
 RUN dnf install -y git-core python3-markdown python3-setuptools python3-affine python3-shapely pstoedit && dnf clean all
 
 # Get Boxes.py sources to /boxes
-RUN git clone --depth 1 -b master https://github.com/florianfesti/boxes.git
+ARG BUILD_BRANCH=master
+ARG BUILD_REPO=https://github.com/florianfesti/boxes.git
+RUN git clone ${BUILD_REPO} && cd boxes && git checkout ${BUILD_BRANCH}
+RUN chmod +x /boxes/scripts/boxesserver
 
 # Internal port used
 EXPOSE 8000

--- a/scripts/boxesserver
+++ b/scripts/boxesserver
@@ -565,7 +565,7 @@ if __name__=="__main__":
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--host", default="")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--url_prefix", default="",
                         help="URL path to Boxes.py instance")


### PR DESCRIPTION
commit 0a8dcf0e37880c056d85523cdea97d8c8b166c6e caused the server to *only* respond to localhost by default.  This causes the Docker to not respond properly.  The old server had the default server name as '', but the new one set it to 'localhost'.

This fixes that problem.

In addition, This commit changes the docker file so that you can specify which git repo and commit to check out from.  This allows trivial testing of other forks/branches/users.  The default branch is master and default git repo is Florian's, but you  can now specify new commits and/or branches to clone with

```docker build --build-arg BUILD_BRANCH=<branch-or-commit> --build-arg BUILD_REPO=<my-repo> ...```