### PR TITLE
Do traylayout in one step

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -285,6 +285,7 @@ class Boxes:
 
     webinterface = True
     ui_group = "Misc"
+    UI = ""
 
     description: str = ""  # Markdown syntax is supported
 

--- a/boxes/generators/gridfinitytraylayout.py
+++ b/boxes/generators/gridfinitytraylayout.py
@@ -1,10 +1,10 @@
 import boxes
 from boxes import Boxes
-from boxes.generators.traylayout import TrayLayout, TrayLayout2
+from boxes.generators.traylayout import TrayLayout
 from boxes.Color import Color
 from boxes import restore
 
-class GridfinityTrayLayout(TrayLayout2):
+class GridfinityTrayLayout(TrayLayout):
     """A Gridfinity Tray Generator based on TrayLayout"""
 
     description = """

--- a/boxes/generators/traylayout.py
+++ b/boxes/generators/traylayout.py
@@ -19,7 +19,7 @@ import boxes
 from boxes import *
 
 
-class TrayLayout(Boxes):
+class TrayLayoutFile(Boxes):
     """Generate a layout file for a typetray."""
     # This class generates the skeleton text file that can then be edited
     # to describe the actual box
@@ -29,7 +29,7 @@ The layout is based on a grid of sizes in x and y direction.
 Choose how many distances you need in both directions.
 The actual sizes and all other settings can be entered in the second step."""
 
-    webinterface = True
+    webinterface = False
 
     ui_group = "Tray"
 
@@ -83,13 +83,13 @@ The actual sizes and all other settings can be entered in the second step."""
             f.write(str(self))
 
 
-class TrayLayout2(Boxes):
+class TrayLayout(Boxes):
     """Generate a typetray from a layout file."""
 
     # This class reads in the layout either from a file (with --input) or
     # as string (with --layout) and turns it into a drawing for a box.
 
-    webinterface = True
+    ui_group = "Tray"
 
     description = """This is a two step process. This is step 2.
 Edit the layout text graphics to adjust your tray.
@@ -98,19 +98,19 @@ vertical bars representing the walls with a space character to remove the walls.
 You can replace the space characters representing the floor by a "X" to remove the floor for this compartment.
 """
 
-    def __init__(self, input=None, webargs=False) -> None:
-        Boxes.__init__(self)
+    def __init__(self) -> None:
+        super().__init__()
         self.addSettingsArgs(boxes.edges.FingerJointSettings)
-        self.buildArgParser("h", "hi", "outside")
-        if not webargs:
+        self.buildArgParser("h", "hi", "outside", "sx", "sy")
+        if self.UI == "web":
+            self.argparser.add_argument(
+                "--layout", action="store", type=str, default="")
+        else:
             self.argparser.add_argument(
                 "--input", action="store", type=argparse.FileType('r'),
                 default="traylayout.txt",
                 help="layout file")
             self.layout = None
-        else:
-            self.argparser.add_argument(
-                "--layout", action="store", type=str, default="")
 
     def vWalls(self, x: int, y: int) -> int:
         """Number of vertical walls at a crossing."""

--- a/scripts/boxesserver
+++ b/scripts/boxesserver
@@ -113,11 +113,11 @@ class BServer:
 
     def __init__(self, url_prefix="", static_url="static") -> None:
         self.boxes = {b.__name__: b for b in boxes.generators.getAllBoxGenerators().values() if b.webinterface}
-        self.boxes['TrayLayout2'] = boxes.generators.traylayout.TrayLayout2  # type: ignore  # no attribute "traylayout"
         self.groups = boxes.generators.ui_groups
         self.groups_by_name = boxes.generators.ui_groups_by_name
 
         for name, box in self.boxes.items():
+            box.UI = "web"
             self.groups_by_name.get(box.ui_group,
                                     self.groups_by_name["Misc"]).add(box)
 
@@ -351,8 +351,6 @@ class BServer:
   <div id="{nr}">\n   <ul>\n''')
             for box in group.generators:
                 name = box.__name__
-                if name in ("TrayLayout2",):
-                    continue
                 docs = ""
                 if box.__doc__:
                     docs = " - " + _(box.__doc__)
@@ -595,10 +593,7 @@ class BServer:
                 self._cache[lang_name] = list(self.genPageMenu(lang))
             return self._cache[lang_name]
 
-        if name == "TrayLayout2":
-            box = box_cls(self, webargs=True)
-        else:
-            box = box_cls()
+        box = box_cls()
 
         box.translations = lang
 
@@ -618,18 +613,6 @@ class BServer:
         except ArgumentParserError as e:
             start_response(status, headers)
             return self.genPageError(name, e, lang)
-        if name == "TrayLayout":
-            start_response(status, headers)
-            box.fillDefault(box.sx, box.sy)
-            layout2 = boxes.generators.traylayout.TrayLayout2(self, webargs=True)
-            layout2.argparser.set_defaults(layout=str(box))
-            return self.args2html(name, layout2, lang, action="TrayLayout2")
-        if name == "TrayLayout2":
-            try:
-                box.parse(box.layout.split("\n"))
-            except Exception as e:
-                start_response(status, headers)
-                return self.genPageError(name, e, lang)
 
         try:
             fd, box.output = tempfile.mkstemp()


### PR DESCRIPTION
I have created a gridfinity generator from traylayout.  But in the process I added a bit of javascript so that TrayLayout can be done in a single step.  

Here's an example interaction: https://youtu.be/-FVWVScKaLA

Let me know if you think that makes sense and I can fix it up (for example, the layout i always auto-generated right now, even when it shouldn't be, like with 'save to url'.  It should also prompt the user to regenerate if it's been hand modified).

Also, I deleted the special TrayLayout handling code in boxesserver and other places.

If you don't like it for TrayLayout, that's fine -- though I think i'll keep it for my GridfinityTrayLayout (not quite ready, but works great)