### PR TITLE
Add search box

### DIFF
--- a/scripts/boxesserver
+++ b/scripts/boxesserver
@@ -303,9 +303,16 @@ class BServer:
 <div style="width: 25%; float: left;">
 <img alt="self-Logo" src="{self.static_url}/boxes-logo.svg" width="250">
 </div>
+
 <div>
+
 <div class="clear"></div>
 <hr>
+
+<div class="search"><form onkeydown="return event.key != 'Enter';" onkeyup=filterSearchItems(); return event.key;">
+\U0001f50d <input autocomplete="off" type="search" onsearch="filterSearchItems();" name="search" id="search"></input>
+</form></div>
+
 <div class="menu" style="width: 100%">
 <img style="width: 200px;" id="sample-preview" src="{self.static_url}/nothing.png" alt="">
 """]
@@ -321,7 +328,7 @@ class BServer:
 >
     {_(group.title)}
 </h3>
-  <div id="{nr}"><ul>''')
+  <div id="{nr}">\n   <ul>\n''')
             for box in group.generators:
                 name = box.__name__
                 if name in ("TrayLayout2",):
@@ -329,8 +336,8 @@ class BServer:
                 docs = ""
                 if box.__doc__:
                     docs = " - " + _(box.__doc__)
-                result.append(f"""<li class="thumbnail" data-thumbnail="{self.static_url}/samples/{name}-thumb.jpg"><a href="{name}{langparam}">{_(name)}</a>{docs}</li>""")
-            result.append("\n</ul></div>\n")
+                result.append(f"""     <li class="thumbnail" data-thumbnail="{self.static_url}/samples/{name}-thumb.jpg" id="search_id_{name}"><a href="{name}{langparam}">{_(name)}</a>{docs}</li>\n""")
+            result.append("   </ul>\n  </div>\n")
         result.append(f"""
 </div>
 

--- a/static/self.css
+++ b/static/self.css
@@ -49,6 +49,7 @@ h3 {
     padding: 5px;
     padding-left: 15px;
     margin: 0px;
+    width: 75%
 }
 
 h3::before {
@@ -136,6 +137,10 @@ video {
     list-style-type: circle;
     display: inline-block;
     font-size: 0.9em;
+}
+
+.search {
+    float : right;
 }
 
 .footer ul li a {

--- a/static/self.js
+++ b/static/self.js
@@ -15,18 +15,28 @@ function hideThumbnail() {
     img.style.display = "none";
 }
 
-
+function expandId(id) {
+    const e = document.getElementById(id);
+    const h = document.getElementById("h-" + id);
+    e.style.display = "block";
+    h.classList.add("open");
+    h.setAttribute("aria-expanded", "true");
+}
+function collapseId(id) {
+    const e = document.getElementById(id);
+    const h = document.getElementById("h-" + id);
+    e.style.display = "none";
+    h.classList.remove("open");
+    h.setAttribute("aria-expanded", "false");
+}
+    
 function toggleId(id) {
     const e = document.getElementById(id);
     const h = document.getElementById("h-" + id);
     if (e.style.display == null || e.style.display === "none") {
-        e.style.display = "block";
-        h.classList.add("open");
-        h.setAttribute("aria-expanded", "true");
+        expandId(id);
     } else {
-        e.style.display = "none";
-        h.classList.remove("open");
-        h.setAttribute("aria-expanded", "false");
+        collapseId(id);
     }
 }
 
@@ -157,4 +167,48 @@ document.addEventListener('DOMContentLoaded', function() {
 }, false);
 
 
+function collapseAll() {
+    const h = document.getElementsByClassName("toggle");
+    for (let el of h) {
+        id = el.getAttribute("data-id")
+        collapseId(id);
+    }
+}
 
+function expandAll() {
+    const h = document.getElementsByClassName("toggle");
+    for (let el of h) {
+        id = el.getAttribute("data-id")
+        expandId(id);
+    }
+}
+
+function showAll(str) {
+    let matching_ids = document.querySelectorAll('[id^="search_id_"]')
+    for (let id of matching_ids) {
+        id.hidden = false;
+    }
+}
+
+function showOnly(str) {
+    str = str.toLowerCase();
+    let matching_ids = document.querySelectorAll('[id^="search_id_"]')
+    for (let id of matching_ids) {
+        name = id.id.replace("search_id_", "").toLowerCase();
+        if (name.includes(str) || id.textContent.toLowerCase().includes(str))
+            id.hidden = false;
+        else
+            id.hidden = true;
+    }
+}
+
+function filterSearchItems() {
+    const search = document.getElementById("search")
+    if (search.value.length == 0) {
+        collapseAll();
+        showAll()
+    } else {
+        expandAll();
+        showOnly(search.value)
+    }
+}


### PR DESCRIPTION
I think this search box works reasonably well, and doesn't look horrid.  Maybe best to put the search bar somewhere else?

Here's a screenshot of how it works.  It auto-filters and displays only the generators that contain the search string. 

Should this be a regex search?  Or just a regular search?  Currently, it's just a regular 'if generator name contains substring' kind of search.

![image](https://user-images.githubusercontent.com/286973/216482198-98c45ad1-0b4d-4663-b864-c111361bb781.png)

As soon as you hit the little 'x' or remove everything from the search box, it reverts back to the original expand/collapse behavior.

