### PR TITLE
Refactor generator `traylayout`

### DIFF
--- a/scripts/boxesserver
+++ b/scripts/boxesserver
@@ -620,7 +620,7 @@ class BServer:
             return self.genPageError(name, e, lang)
         if name == "TrayLayout":
             start_response(status, headers)
-            box.fillDefault(box.x, box.y)
+            box.fillDefault(box.sx, box.sy)
             layout2 = boxes.generators.traylayout.TrayLayout2(self, webargs=True)
             layout2.argparser.set_defaults(layout=str(box))
             return self.args2html(name, layout2, lang, action="TrayLayout2")


### PR DESCRIPTION
## Reference

Suggestion: https://github.com/florianfesti/boxes/pull/529#issuecomment-1412699778

By default an unusable box is generated: #541

## Changes

* Use generic argument `sx` and `sy` to generate text traylayout
* Add typing
* Fix code style

## Impact

By default a usable box is generated.

New input:

![grafik](https://user-images.githubusercontent.com/7337347/221685507-b092bccd-4eef-40ea-86f7-6fb9eca48e83.png)


Output: 

```
 ,> 50.0mm
 | ,> 50.0mm
 | | ,> 50.0mm
+-+-+-+
| | | | 50.0mm
+-+-+-+
| | | | 50.0mm
+-+-+-+
| | | | 50.0mm
+-+-+-+