### PR TITLE
Fixed flanged front wall top edge spacing in rack19box

### DIFF
--- a/boxes/generators/rack19box.py
+++ b/boxes/generators/rack19box.py
@@ -80,7 +80,7 @@ class Rack19Box(Boxes):
         self.rectangularWall(y, h, "ffef", callback=[self.wallyCB], move="right")
         self.rectangularWall(x, h, "fFeF", callback=[self.wallxCB],
                              move="up")
-        self.flangedWall(x, h, "FFeF", callback=[self.wallxfCB], r=t,
+        self.flangedWall(x, h, "FFEF", callback=[self.wallxfCB], r=t,
                          flanges=[0., 17., -t, 17.])
         self.rectangularWall(y, h, "ffef", callback=[self.wallyCB],
                              move="left up")


### PR DESCRIPTION
You just have to render any rack19box to see the bug in the rendering of the front panel. This code fixes it. Cheers!