### PR TITLE
Fix type error: no attribute "thickness"  [attr-defined]

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -312,6 +312,9 @@ class Boxes:
             "cli_short" : "",
         }
 
+        # Dummy attribute for static analytic tools. Will be overwritten by `argparser` at runtime.
+        self.thickness: float = 0.0
+
         self.argparser._action_groups[1].title = self.__class__.__name__ + " Settings"
         defaultgroup = self.argparser.add_argument_group(
                         "Default Settings")


### PR DESCRIPTION
Fix the CI error. Attribute is set at runtime by the arg parser.