### PR TITLE
Add qrcode to setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     url='https://github.com/florianfesti/boxes',
     packages=find_packages(),
     python_requires='>=3.7',
-    install_requires=['affine>=2.0', 'markdown', 'shapely>=1.8.2'],
+    install_requires=['affine>=2.0', 'markdown', 'shapely>=1.8.2', 'qrcode==7.3.1'],
     scripts=['scripts/boxes', 'scripts/boxesserver'],
     cmdclass={
         'build_py': CustomBuildExtCommand,


### PR DESCRIPTION
Add `qrcode==7.3.1` to `setup.py` `install_requires` to match `requirements.txt`.