### PR TITLE
Remove support of EOL Python 3.7

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     author_email='florian@festi.info',
     url='https://github.com/florianfesti/boxes',
     packages=find_packages(),
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=['affine>=2.0', 'markdown', 'shapely>=1.8.2', 'qrcode==7.3.1'],
     scripts=['scripts/boxes', 'scripts/boxesserver'],
     cmdclass={


### PR DESCRIPTION
Reached end of life 2023-06-27
https://devguide.python.org/versions/