### PR TITLE
Update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,8 @@ updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
-      #timezone: "Europe/Berlin"
-      #day: "sunday"
-      #time: "05:00"
-    labels:
-      - "github-actions-dependencies"
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
* monthly scan is sufficient for github actions
* remove wrong label
* group pull request (https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/)