### PR TITLE
Correct format specifier

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -406,10 +406,10 @@ class Boxes:
             self.move(self.reference, 10, "up", before=True)
             self.ctx.rectangle(0, 0, self.reference, 10)
             if self.reference < 80:
-                self.text(f"{self.reference:.f}mm, burn:{self.burn:.2f}mm", self.reference + 5, 5,
+                self.text(f"{self.reference:.2f}mm, burn:{self.burn:.2f}mm", self.reference + 5, 5,
                           fontsize=8, align="middle left", color=Color.ANNOTATIONS)
             else:
-                self.text(f"{self.reference:.f}mm, burn:{self.burn:.2f}mm", self.reference / 2.0, 5,
+                self.text(f"{self.reference:.2f}mm, burn:{self.burn:.2f}mm", self.reference / 2.0, 5,
                           fontsize=8, align="middle center", color=Color.ANNOTATIONS)
             self.move(self.reference, 10, "up")
             if self.qr_code:


### PR DESCRIPTION
Hi, 
I had to patch a format specifier in order to get boxes works locally on my computer.
Default precision specifier is not `{var:.f}` but `{var:f}` (at least on my PC with python 3.11.5)
I'm not sure if it universal but here is the patch
Cheers