### PR TITLE
docs: rst format

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -141,7 +141,7 @@ perfect. We can work on it together.
 Running the Code
 ----------------------------
 
-To serve website, run `scripts/boxesserver` script
+To serve website, run :code:`scripts/boxesserver` script.
 
 Reporting bugs
 --------------

--- a/documentation/src/api_architecture.rst
+++ b/documentation/src/api_architecture.rst
@@ -8,7 +8,7 @@ User Interfaces
 
 User interfaces allow users to render the different generators. They
 handle the parameters of Generators and convert them to a readable
-form. The user interfaces are located in `scripts/`. Currently there is
+form. The user interfaces are located in :code:`scripts/`. Currently there is
 
 * scripts/boxes -- the command line interface
 * scripts/boxesserver -- the web interface

--- a/documentation/src/index.rst
+++ b/documentation/src/index.rst
@@ -1,7 +1,5 @@
 .. boxes.py documentation master file, created by
    sphinx-quickstart on Sun Mar 27 12:04:59 2016.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
 
 Boxes.py
 ========

--- a/documentation/src/install.rst
+++ b/documentation/src/install.rst
@@ -44,7 +44,7 @@ in the :code:`boxes.formats.Formats` class.
 Python
 ......
 
-Boxes.py is implemented in Python 3. For supported minor version see `setup.py`.
+Boxes.py is implemented in Python 3. For supported minor version see :code:`setup.py`.
 
 Sphinx
 ......


### PR DESCRIPTION
Add missing `:code:`