### PR TITLE
[rack19box] more laser-cutter-friendly layout

### DIFF
--- a/boxes/generators/rack19box.py
+++ b/boxes/generators/rack19box.py
@@ -78,16 +78,16 @@ class Rack19Box(Boxes):
 
         self.rectangularWall(y, h, "ffef", callback=[self.wallyCB],
                              move="right", label="right")
-        self.rectangularWall(x, h, "fFeF", callback=[self.wallxCB],
-                             move="up", label="back")
         self.flangedWall(x, h, "FFEF", callback=[self.wallxfCB], r=t,
-                         flanges=[0., 17., -t, 17.], label="front")
+                         flanges=[0., 17., -t, 17.], move="up", label="front")
+        self.rectangularWall(x, h, "fFeF", callback=[self.wallxCB],
+                             label="back")
         self.rectangularWall(y, h, "ffef", callback=[self.wallyCB],
                              move="left up", label="left")
 
-        self.rectangularWall(x, y, "fFFF", move="right", label="bottom")
+        self.rectangularWall(x, y, "fFFF", move="up", label="bottom")
         self.rectangularWall(x, y, callback=[
-            lambda:self.hole(trh, trh, d=d2)] * 4, move='up', label="lid")
+            lambda:self.hole(trh, trh, d=d2)] * 4, move='right', label="lid")
 
         self.rectangularTriangle(tr, tr, "ffe", num=4,
             callback=[None, lambda: self.hole(trh, trh, d=d1)])

--- a/boxes/generators/rack19box.py
+++ b/boxes/generators/rack19box.py
@@ -76,17 +76,18 @@ class Rack19Box(Boxes):
         tr = self.triangle
         trh = tr / 3.
 
-        self.rectangularWall(y, h, "ffef", callback=[self.wallyCB], move="right")
-        self.rectangularWall(x, h, "fFeF", callback=[self.wallxCB],
-                             move="up")
-        self.flangedWall(x, h, "FFEF", callback=[self.wallxfCB], r=t,
-                         flanges=[0., 17., -t, 17.])
         self.rectangularWall(y, h, "ffef", callback=[self.wallyCB],
-                             move="left up")
+                             move="right", label="right")
+        self.rectangularWall(x, h, "fFeF", callback=[self.wallxCB],
+                             move="up", label="back")
+        self.flangedWall(x, h, "FFEF", callback=[self.wallxfCB], r=t,
+                         flanges=[0., 17., -t, 17.], label="front")
+        self.rectangularWall(y, h, "ffef", callback=[self.wallyCB],
+                             move="left up", label="left")
 
-        self.rectangularWall(x, y, "fFFF", move="right")
+        self.rectangularWall(x, y, "fFFF", move="right", label="bottom")
         self.rectangularWall(x, y, callback=[
-            lambda:self.hole(trh, trh, d=d2)] * 4, move='up')
+            lambda:self.hole(trh, trh, d=d2)] * 4, move='up', label="lid")
 
         self.rectangularTriangle(tr, tr, "ffe", num=4,
             callback=[None, lambda: self.hole(trh, trh, d=d1)])


### PR DESCRIPTION
My laser cutter is pretty big, but not big enough for two 19-inch parts side-by-side. Assuming that most users are going to be in a similar position, this stacks the widest parts vertically (tested with default settings + the 1u settings for my own project + some other random combinations to check for glitches)

(Also I added labels to help me mentally map the code to the parts ^^)

Before:
![Screenshot 2023-11-22 at 10 44 41](https://github.com/florianfesti/boxes/assets/40659/010b34e7-d2ac-4846-af2a-894d5ec63e7e)

After:
![Screenshot 2023-11-22 at 10 42 38](https://github.com/florianfesti/boxes/assets/40659/4c88c770-08c9-402e-90e7-9beb225d258e)
