### PR TITLE
Add precommit basic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.py text eol=lf
+*.sh text eol=lf

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.8", "3.12" ] # Lowest and highest.
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+      with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip" # caching pip dependencies
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+ci:
+  autofix_prs: true
+  autoupdate_schedule: quarterly
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: requirements-txt-fixer
+      - id: check-case-conflict
+      - id: detect-private-key
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0  # Use the ref you want to point at
+    hooks:
+      - id: python-use-type-annotations
+      - id: python-no-eval
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+      - id: pyupgrade
+        args: [ --py38-plus ]
+
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.2.0
+    hooks:
+      - id: rstcheck
+        args: [ "--report-level=warning", "--ignore-directives=autoclass,automethod,automodule" ]
+        additional_dependencies: [ sphinx ]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.6
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        exclude: ^(boxes|locale|po|static)/ # todo folder boxes

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,6 +54,19 @@ If you want feed back on you code feel free to open a PR. State that
 this is work in progress in the PR message. It's OK if it does not
 follow the guidelines (yet).
 
+Check Code
+..........
+
+The `pre-commit <https://pre-commit.com/>`_ tool is used to verify the code style.
+When installed, it automatically checks and corrects the code before each commit.
+
+* Install *pre-commit*, e.g. :code:`pip install pre-commit`
+* Install githook :code:`pre-commit install`
+
+For manual check use :code:`pre-commit run --all-files`.
+
+To remove githook use :code:`pre-commit uninstall`.
+
 Writing new Generators
 ......................
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,4 @@
+inkex
+mypy
+pre-commit
+types-Markdown


### PR DESCRIPTION
Possible configuration for pre-commit as suggested in #600 .

Less extensive version of #601.

Features:

* sorting of `requirements.txt`
* correct execution permissions
* spelling docs-folder
* run `shellcheck`
* run `rstcheck` and other `rst` markup checks
* run `pyupgrade` to avoid old python code style
