### PR TITLE
fix: remove shebang because not an executable

### DIFF
--- a/boxes/generators/airpurifier.py
+++ b/boxes/generators/airpurifier.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (C) 2013-2016 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/keyholder.py
+++ b/boxes/generators/keyholder.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (C) 2013-2014 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/pizzashovel.py
+++ b/boxes/generators/pizzashovel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (C) 2013-2016 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify

--- a/boxes/generators/skadis.py
+++ b/boxes/generators/skadis.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (C) 2013-2016 Florian Festi
 #
 #   This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Not marked as executable and should not be executable. Seems leftover from dev.