### PR TITLE
Add settings for bed bolts

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -389,7 +389,6 @@ class Boxes:
         if self.ctx is not None:
             return
 
-        self.bedBoltSettings = (3, 5.5, 2, 20, 15)  # d, d_nut, h_nut, l, l1
         self.surface, self.ctx = self.formats.getSurface(self.format, self.output)
 
         if self.format == 'svg_Ponoko':
@@ -643,6 +642,10 @@ class Boxes:
         self.lidSettings = lids.LidSettings(self.thickness, True,
                                        **self.edgesettings.get("Lid", {}))
         self.lid = lids.Lid(self, self.lidSettings)
+
+        # Bed Bolts
+        bedbolt_settings = self.edgesettings.get("BedBolt") or edges.BedBoltSettings.absolute_params
+        self.bedBoltSettings = edges.BedBoltSettings.convert_settings_to_tuple(bedbolt_settings)
 
         # Nuts
         self.addPart(NutHole(self, None))

--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -2657,3 +2657,29 @@ class HandleHoleEdge(HandleEdge):
 
     def margin(self) -> float:
         return self.settings.height + self.extra_height * self.settings.thickness
+
+
+class BedBoltSettings(Settings):
+    """Settings for bed bolts
+Values:
+
+* absolute_params
+
+ * d     :  : Bore and slit diameter [mm] (eg. 4.0 for M4)
+ * d_nut :  : Width of the nut [mm] (eg. 7.0 for M4)
+ * h_nut :  : Height of the nut [mm] (not standardized, roughly 2.4 for M4)
+ * l     :  : Total slit length of the nut [mm] (eg. 17.0 for an M? x 20, accounting for 4mm thickness and giving 1mm tolerance)
+ * l1    :  : Distance from the cut edge to the close edge of the nut [mm]
+"""
+
+    absolute_params = {
+        "d": 3.0,
+        "d_nut": 5.5,
+        "h_nut": 2.0,
+        "l": 20.0,
+        "l1": 15.0,
+    }
+
+    @classmethod
+    def convert_settings_to_tuple(cls, args):
+        return (args['d'], args['d_nut'], args['h_nut'], args['l'], args['l1'])

--- a/boxes/generators/closedbox.py
+++ b/boxes/generators/closedbox.py
@@ -30,7 +30,12 @@ See BasedBox for variant with a base."""
     def __init__(self) -> None:
         Boxes.__init__(self)
         self.addSettingsArgs(edges.FingerJointSettings)
+        self.addSettingsArgs(edges.BedBoltSettings)
         self.buildArgParser("x", "y", "h", "outside")
+
+        self.argparser.add_argument(
+            "--bedbolts",  action="store", type=boolarg, default=False,
+            help="Use bed bolts")
 
     def render(self):
 
@@ -43,10 +48,11 @@ See BasedBox for variant with a base."""
 
         t = self.thickness
 
-        d2 = edges.Bolts(2)
-        d3 = edges.Bolts(3)
-
-        d2 = d3 = None
+        if self.bedbolts:
+            d2 = edges.Bolts(2)
+            d3 = edges.Bolts(3)
+        else:
+            d2 = d3 = None
 
         self.rectangularWall(x, h, "FFFF", bedBolts=[d2] * 4, move="right", label="Wall 1")
         self.rectangularWall(y, h, "FfFf", bedBolts=[d3, d2, d3, d2], move="up", label="Wall 2")


### PR DESCRIPTION
This adds user configurable Settings for bed bolts. It's a *bit* odd because so far all previous pluggable Settings were for edges (and bed bolts are not really edges, but more like a tool that fingers can use), but it still works well.

To have an example, the closedbox (which already had bedbolts in the source but they were commented out) gains a configurable option to enable them.

There is one more change that'd make sense in my opinion, but it'll prefer to discuss that a bit first: I think that edge.Bolts should grow a second argument "layers", which defaults to 1 and is ignored on the drilling side. The total length is reduced by thickness * layers. This way, we can have the user configurable length parameter the length of the screw (plus tolerance), and depending on the number of sheets (with round holes) this will be screwed through, the length will be reduced accordingly. After all, as a user configuring this, I'll know the length of my screws, and I'll configure the thickness, but I'd use the same screws everywhere, and if there is in some place a constellation of two layers (which may happen in the box I'm doing this for), that should be accounted for by the box script. 