### PR TITLE
Added feature: grippy corners

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -1017,18 +1017,30 @@ class Boxes:
 
         self.move(tw, th, move)
 
-    def grip(self, length, depth):
+    def grip(self, length, depth, degrees=0):
         """Corrugated edge useful as a gipping area
 
         :param length: length
         :param depth: depth of the grooves
+        :param degrees: angle of an arc
         """
         grooves = max(int(length // (depth * 2.0)) + 1, 1)
+        degrees_per_groove = degrees
         depth = length / grooves / 4.0
         for groove in range(grooves):
             self.corner(90, depth)
-            self.corner(-180, depth)
+            self.corner(-180 + degrees_per_groove, depth)
             self.corner(90, depth)
+
+    def gripCorner(self, degrees, radius, depth):
+        """Corrugated edge useful as a gipping area around a corner, or for making grippy circles.
+
+        :param degrees: angle
+        :param radius: radius
+        :param depth: depth of the grooves
+        """
+        length = degrees / 360 * 2 * math.pi * radius
+        self.grip(length, depth, degrees)
 
     def _latchHole(self, length):
         """


### PR DESCRIPTION
In a generator I am working on, it is helpful to create circles with grip on them. More generally, it seems useful to be able to create curves or corners with the same kind of corrugation as `self.grip()`.

To DRY as much as possible, I've added a new parameter to `self.grip(...)` to take a number of degrees over which it will arc (defaulting to 0), and then creating `self.gripCorner(...)` with an API similar to `self.corner(...)`