### PR TITLE
Make better use of part names

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -1217,7 +1217,7 @@ class Boxes:
                     self.moveTo(x, 0)
                     self.ctx.scale(-1, 1)
                 self.moveTo(self.spacing / 2.0, self.spacing / 2.0)
-        self.ctx.new_part()
+        self.ctx.new_part(previous_part_name=label)
 
         return dontdraw
 

--- a/boxes/drawing.py
+++ b/boxes/drawing.py
@@ -536,6 +536,8 @@ Creation date: {date}
                 continue
             g = ET.SubElement(svg, "g", id=f"p-{i}",
                               style="fill:none;stroke-linecap:round;stroke-linejoin:round;")
+            if part.name:
+                ET.SubElement(g, "title").text = part.name
             g.text = "\n  "
             g.tail = "\n"
             for j, path in enumerate(part.pathes):

--- a/boxes/drawing.py
+++ b/boxes/drawing.py
@@ -87,7 +87,17 @@ class Surface:
         for p in self.parts:
             p.transform(f, m, invert_y)
 
-    def new_part(self, name="part"):
+    def new_part(self, name="part", previous_part_name=None):
+        """Insert a new part into the surface; any subsequent drawing commands
+        will be grouped into this part, and the previously active part is
+        closed.
+
+        previous_part_name allows naming the part that is being closed. This
+        allows parts created by the Boxes.move mechanism to obtain their
+        names."""
+        if previous_part_name is not None:
+            assert self.parts, "previous_part_name can not be set for the first part on a surface"
+            self.parts[-1].name = previous_part_name
         if self.parts and len(self.parts[-1].pathes) == 0:
             return self._p
         p = Part(name)
@@ -115,6 +125,7 @@ class Surface:
 
 class Part:
     def __init__(self, name) -> None:
+        self.name: str = name
         self.pathes: list[Any] = []
         self.path: list[Any] = []
 
@@ -402,8 +413,8 @@ class Context:
         # self.stroke()
 
     ## additional methods
-    def new_part(self):
-        self._dwg.new_part()
+    def new_part(self, *args, **kwargs):
+        self._dwg.new_part(*args, **kwargs)
 
 
 class SVGSurface(Surface):


### PR DESCRIPTION
So far, part names are only used to place red text labels.

This change stores the names in the parts (the constructor argument was previously ignored; an extra argument is added to new_part to account for its typical usage pattern where drawing happens on the last set part, and a new part is created at the end of drawing).

A second commit uses the data that is now stored to make names accessible in browsers' tooltips. Future changes enabled by this would be making parts more easily accessible in DXF as well, eg. to extract them for further processing into 3D models.