### PR TITLE
feat: add metadata for reproducible generation

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -306,6 +306,7 @@ class Boxes:
             "cli": "",
             "cli_short": "",
             "creation_date": datetime.datetime.now(),
+            "reproducible": False,  # If True output does not contain variable content like creation date.
         }
 
         # Dummy attribute for static analytic tools. Will be overwritten by `argparser` at runtime.

--- a/boxes/drawing.py
+++ b/boxes/drawing.py
@@ -443,7 +443,8 @@ class SVGSurface(Surface):
         w.text = '\n'
 
         self._addTag(w, 'dc:title', title)
-        self._addTag(w, 'dc:date', creation_date)
+        if not md["reproducible"]:
+            self._addTag(w, 'dc:date', creation_date)
 
         if "url" in md and md["url"]:
             self._addTag(w, 'dc:source', md["url"])
@@ -472,7 +473,8 @@ class SVGSurface(Surface):
         if md["description"]:
             txt += """\n\n{description}\n\n""".format(**md)
         txt += """\nCreated with Boxes.py (https://festi.info/boxes.py)\n"""
-        txt += f"""Creation date: {creation_date}\n"""
+        if not md["reproducible"]:
+            txt += f"""Creation date: {creation_date}\n"""
 
         txt += "Command line (remove spaces between dashes): %s\n" % md["cli_short"]
 
@@ -612,7 +614,8 @@ class PSSurface(Surface):
 
         desc = ""
         desc += "%%Title: Boxes.py - {group} - {name}\n".format(**md)
-        desc += f'%%CreationDate: {md["creation_date"].strftime("%Y-%m-%d %H:%M:%S")}\n'
+        if not md["reproducible"]:
+            desc += f'%%CreationDate: {md["creation_date"].strftime("%Y-%m-%d %H:%M:%S")}\n'
         desc += f'%%Keywords: boxes.py, laser, laser cutter\n'
         desc += f'%%Creator: {md.get("url") or md["cli"]}\n'
         desc += "%%CreatedBy: Boxes.py (https://festi.info/boxes.py)\n"


### PR DESCRIPTION
### Change

Adds option to remove non reproducible data from generated file like creation time.

### Use-case

This is useful if the generated (svg) file is committed to a git or other versioning system. If box generation is not changed it will not trigger a new version.

It also can be used for tests.