### PR TITLE
Shadowbox improvements

### DIFF
--- a/boxes/generators/shadowbox.py
+++ b/boxes/generators/shadowbox.py
@@ -107,3 +107,9 @@ See the diagram below for dimensions.
         self.rectangularWall(x, height, f"ef{top_edge}f", move="up")
         self.rectangularWall(y, height, f"eF{top_edge}F", move="up")
         self.rectangularWall(y, height, f"eF{top_edge}F", move="up")
+
+        # led strip holder
+        self.rectangularWall(x - 2*t, 10, "efef", move="up")
+        self.rectangularWall(x - 2*t, 10, "efef", move="up")
+        self.rectangularWall(y - 2*t, 10, "eFeF", move="up")
+        self.rectangularWall(y - 2*t, 10, "eFeF", move="up")

--- a/boxes/generators/shadowbox.py
+++ b/boxes/generators/shadowbox.py
@@ -87,15 +87,14 @@ See the diagram below for dimensions.
             y - frameheight*2, 90-angle,
             hypotenuse, 90+angle]
         hframe_poly = [
-            t, 0, x, 0, t, 90+angle,
-            hypotenuse, 90-angle,
-            x - framewidth*2, 90-angle,
-            hypotenuse, 90+angle]
+            t, 0, x, 0, t, 180-angle,
+            hypotenuse, angle,
+            x - framewidth*2, angle,
+            hypotenuse, 180-angle]
 
         self.polygonWall(vframe_poly, edgetypes, move="up")
         self.polygonWall(vframe_poly, edgetypes, move="up")
 
-        angle = 90 - angle
         self.polygonWall(hframe_poly, edgetypes, move="up")
         self.polygonWall(hframe_poly, edgetypes, move="up")
 


### PR DESCRIPTION
**Commit 1:**
I made an error with the angles when refactoring, rendering the angle complement calculation ineffective, making them wrong when the angle is not 45 degrees.

**Commit 2:**
I have also added parts to glue the LED strip onto.

**Not yet committed:**
The look of the shadowbox is *greatly* improved by adding a frame around it with nicer wood:
![PXL_20240330_234543198(1)](https://github.com/florianfesti/boxes/assets/2729228/9971d827-8bfe-45bd-b793-7d083b6d7c5e)
![PXL_20240330_233651879(1)](https://github.com/florianfesti/boxes/assets/2729228/b692235e-8289-49e7-98a5-2fa93ed34d65)


However, this will tend to be of a different thickness than the main construction (e.g. 3mm vs 6mm). I couldn't figure out how to have two different widths apply to finger joints in a single generation, so I don't know how best to do this. To do it myself, I just added them to this generator, ran it twice with different parameters, and manually combined the resulting files as needed.

I suppose I could make a separate "picture frame" generator, but this would require entering a bunch of parameters that are calculated values here.

How would you advise doing this?