### PR TITLE
fix(docs): typo; unclear description

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -1079,7 +1079,7 @@ class Boxes:
 
         :param x: width in mm
         :param h: height in mm
-        :param hl: height if th grip hole
+        :param hl: height if the grip hole
         :param r:  (Default value = 30) radius of the corners
         """
         d = (x - hl - 2 * r) / 2.0
@@ -1222,8 +1222,8 @@ class Boxes:
         """
         Draw a round disc
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param r: radius
         """
         r += self.burn
@@ -1242,8 +1242,8 @@ class Boxes:
         """
         Draw a hole in shape of an n-edged regular polygon
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param r: radius
         :param n: number of edges
         :param a: rotation angle
@@ -1286,8 +1286,8 @@ class Boxes:
         """
         Draw a round hole
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param r: radius
         """
 
@@ -1305,8 +1305,8 @@ class Boxes:
         """
         Draw a rectangular hole
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param dx: width
         :param dy: height
         :param r:  (Default value = 0) radius of the corners
@@ -1328,8 +1328,8 @@ class Boxes:
         """
         Draw a hole for a shaft with flat edge - D shaped hole
 
-        :param x: center position
-        :param y: center position
+        :param x: center x position
+        :param y: center y position
         :param r: radius (overrides d)
         :param d: diameter
         :param w: width measured against flat side in mm
@@ -1360,8 +1360,8 @@ class Boxes:
         """
         Draw a hole for a shaft with two opposed flat edges - ( ) shaped hole
 
-        :param x: center position
-        :param y: center position
+        :param x: center x position
+        :param y: center y position
         :param r: radius (overrides d)
         :param d: diameter
         :param w: width measured against flat side in mm
@@ -1396,8 +1396,8 @@ class Boxes:
         """
         Draw a pear shaped mounting hole for sliding over a screw head. Total height = 1.5* d_shaft + d_head
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param d_shaft: diameter of the screw shaft
         :param d_head: diameter of the screw head
         :param angle: rotation angle of the hole

--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -1039,8 +1039,8 @@ class FingerHoles(FingerJointBase):
         """
         Draw holes for a matching finger joint edge
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param length: length of matching edge
         :param angle:  (Default value = 90)
         :param bedBolts:  (Default value = None)

--- a/boxes/generators/gridfinitytraylayout.py
+++ b/boxes/generators/gridfinitytraylayout.py
@@ -73,8 +73,8 @@ this compartment.
         """
         Draw a rectangular hole
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param dx: width
         :param dy: height
         :param r:  (Default value = 0) radius of the corners

--- a/boxes/generators/photoframe.py
+++ b/boxes/generators/photoframe.py
@@ -538,8 +538,8 @@ interesting in the last 2mm of a photo anyway.
         Draw a rectangular etching (from GridfinityTrayLayout.rectangularEtching)
         Same as rectangularHole, but with no burn margin
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param dx: width
         :param dy: height
         :param r:  (Default value = 0) radius of the corners

--- a/boxes/walledges.py
+++ b/boxes/walledges.py
@@ -121,8 +121,8 @@ class WallHoles(WallEdge):
         """
         Draw holes for a matching WallJoinedEdge
 
-        :param x: position
-        :param y: position
+        :param x: x position
+        :param y: y position
         :param length: length of matching edge
         :param angle:  (Default value = 90)
         """


### PR DESCRIPTION
Fixes IDE hint that there is a duplicate description which should be more specific. 🙄 