### PR TITLE
feat: use new pip install

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,7 @@ jobs:
           cache: "pip" # caching pip dependencies
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          pip install .
       - name: Build documentation
         run: |
           cd ./documentation/src/

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -17,6 +17,6 @@ jobs:
       with:
           python-version: ${{ matrix.python-version }}
           cache: "pip" # caching pip dependencies
-    - run: pip install -r requirements.txt
-    - run: pip install -r requirements_dev.txt
+    - run: pip install .
+    - run: pip install .[dev]
     - uses: pre-commit/action@v3.0.1

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -94,9 +94,9 @@ Adding new dependencies should be considered thoroughly. If a new
 dependency is added it needs to be added in all these places:
 
 If it is a Python module it also needs to be added:
-* *requirements.txt* or *requirements_dev.txt*
-* *setup.py*
 
+* *requirements.txt* or *requirements_dev.txt*
+* *pyproject.toml*
 * *documentation/src/install.rst* (unless a Python module)
 * RST files in *documentation/src/install/*
 * *scripts/Dockerfile*

--- a/documentation/src/install/windows.rst
+++ b/documentation/src/install/windows.rst
@@ -84,7 +84,7 @@ Once wsl is installed, run it and enter the following commands:
 - :code:`cd ~`
 - :code:`git clone https://github.com/florianfesti/boxes.git`
 - :code:`cd ~/boxes`
-- :code:`python3 -m pip install -r ~/boxes/requirements.txt`
+- :code:`python3 -m pip install .`
 - :code:`python3 ~/boxes/scripts/boxesserver`
 
 .. figure:: win11-wsl-boxesserver-localhost.png

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -6,7 +6,7 @@ RUN python3 -m venv env
 RUN /app/env/bin/pip install gunicorn
 
 ADD https://github.com/florianfesti/boxes.git /app
-RUN /app/env/bin/pip install -r requirements.txt
+RUN /app/env/bin/pip install .
 RUN mv scripts/boxesserver scripts/boxesserver.py
 
 # ---


### PR DESCRIPTION
Since `pyproject.toml` is available the pip install can be simplified from

> pip install -r requirements.txt

to

> pip install .