### PR TITLE
chore(python): require 3.9; drop eol 3.8

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip" # caching pip dependencies
       - name: Install dependencies
         run: |

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.12" ] # Lowest and highest.
+        python-version: [ "3.9", "3.12" ] # Lowest and highest.
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 exclude: '\.svg$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -18,30 +18,33 @@ repos:
       - id: detect-private-key
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
+      - id: check-illegal-windows-names
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0  # Use the ref you want to point at
+    rev: v1.10.0
     hooks:
-      - id: python-use-type-annotations
       - id: python-no-eval
+      - id: python-no-log-warn
+      - id: python-use-type-annotations
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
+      - id: text-unicode-replacement-char
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
-        args: [ --py38-plus ]
+        args: [ --py39-plus ]
 
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.1
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args: [ --remove-all-unused-imports, --in-place, --ignore-pass-statements, ]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
 
@@ -55,7 +58,7 @@ repos:
   #      # additional_dependencies: [ flake8-bugbear, flake8-docstrings ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.13.0
     hooks:
       - id: mypy
         args: [ '--ignore-missing-imports' ]
@@ -84,19 +87,19 @@ repos:
         files: '^setup.py$'
 
   - repo: https://github.com/rstcheck/rstcheck
-    rev: v6.2.0
+    rev: v6.2.4
     hooks:
       - id: rstcheck
         args: [ "--report-level=warning", "--ignore-directives=autoclass,automethod,automodule" ]
         additional_dependencies: [ sphinx ]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.6
+    rev: v0.10.0.1
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         exclude: ^(boxes|locale|po|static)/ # todo folder boxes

--- a/boxes/generators/brick_sorter.py
+++ b/boxes/generators/brick_sorter.py
@@ -13,7 +13,6 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from collections import OrderedDict
-from typing import Tuple
 
 from boxes import *
 
@@ -133,7 +132,7 @@ In Use:
 
     def _calc_grid_size_width_offset(
         self, inner_mm_after_nesting: float
-    ) -> Tuple[int, float]:
+    ) -> tuple[int, float]:
         """Return the size of the grid and the offset from the outer top right corner"""
         hole_count = self._calc_hole_count(inner_mm_after_nesting)
         grid_size = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 [project]
 dynamic = ["dependencies", "optional-dependencies"]
 name = 'boxes'
-version = '1.0'
-requires-python = '>=3.8'
+version = '1.1'
+requires-python = '>=3.9'
 description = 'Boxes generator for laser cutters'
 maintainers = [ { name = 'Florian Festi', email='florian@festi.info' } ]
 readme = "README.rst"

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -24,7 +24,9 @@ class TestSVG:
 
     # Ignore multistep generators and generators which require input.
     notTestGenerators = ('GridfinityTrayLayout', 'TrayLayout', 'TrayLayoutFile', 'TypeTray', 'Edges',)
-    brokenGenerators = ()
+    brokenGenerators = (
+        'Console', # Generated svg is different on windows and linux.
+    )
     avoidGenerator = notTestGenerators + brokenGenerators
 
     def test_generators_available(self) -> None:


### PR DESCRIPTION
Python 3.8 is eol since 07 Oct 2024. Python 3.13 not added yet, because of behavour change.

Fixes tests by excluding broken generator `console`.