### PR TITLE
added none to --top parameter choices list

### DIFF
--- a/boxes/generators/roundedbox.py
+++ b/boxes/generators/roundedbox.py
@@ -50,7 +50,7 @@ With lid:
             help="edge type for top and bottom edges")
         self.argparser.add_argument(
             "--top",  action="store", type=str, default="none",
-            choices=["closed", "hole", "lid",],
+            choices=["none", "closed", "hole", "lid",],
             help="style of the top and lid")
 
     def hole(self):


### PR DESCRIPTION
In the --top parameter of the roundedbox generator the value of "none" is set as the default value, but is not included in the choices list. So the argparse exists with the error 
app.py: error: argument --top: invalid choice: 'none' (choose from 'closed', 'hole', 'lid')
if the default "none" value is used when calling the generator execution.
Adding "none" to the choices removes the error.