### PR TITLE
fixed --top parameter default value in roundedregularbox generator

### DIFF
--- a/boxes/generators/roundedregularbox.py
+++ b/boxes/generators/roundedregularbox.py
@@ -44,8 +44,8 @@ class RoundedRegularBox(boxes.Boxes):
             "--wallpieces", action="store", type=int, default=0,
              help="number of pieces for outer wall (0 for one per side)")
         self.argparser.add_argument(
-            "--top",  action="store", type=str, default="none",
-            choices=["closed", "hole", "lid",],
+            "--top",  action="store", type=str, default="hole",
+            choices=["hole", "lid", "closed",],
             help="style of the top and lid")
 
     def holeCB(self):


### PR DESCRIPTION
Same fix as in the commit e80ad1c (https://github.com/florianfesti/boxes/commit/e80ad1c42ac500a3ae6cecb0d767f7f0c3ab3109) but for the roundedregularbox generator.