### PR TITLE
Minor Fixes to GridfinityBase and GridfinityTrayLayout

### DIFF
--- a/boxes/generators/gridfinitybase.py
+++ b/boxes/generators/gridfinitybase.py
@@ -158,8 +158,8 @@ class GridfinityBase(Boxes):
         pad_x = x - (nx * pitch)
         pad_y = y - (ny * pitch)
         # compute maximum number of grids in each panel
-        panel_nx = (self.panel_x // pitch)
-        panel_ny = (self.panel_y // pitch)
+        panel_nx = ((self.panel_x - pad_x) // pitch)
+        panel_ny = ((self.panel_y -pad_y) // pitch)
 
         # Sub-divide the larger Grid into approximately equal sized segments
         # in both X and Y direction, not exceeding the provided panel size

--- a/boxes/generators/gridfinitytraylayout.py
+++ b/boxes/generators/gridfinitytraylayout.py
@@ -103,8 +103,8 @@ this compartment.
         m = self.opening_margin
         self.ctx.stroke()
         with self.saved_context():
-            for xx in [0, self.nx-1]:
-                for yy in [0, self.ny-1]:
+            for xx in {0, self.nx-1}:
+                for yy in {0, self.ny-1}:
                     self.set_source_color(Color.ETCHING)
                     self.rectangularEtching(x+p/2+xx*p, y+p/2+yy*p, o-m, o-m)
             self.ctx.stroke()


### PR DESCRIPTION
- The GridfinityBase can incorrectly split parts in some cases because the split was not accounting for the pad. This was introduced when adding split functionality.
- GridfinityTrayLayout etching of pad locations will write the etching multiple overlapping times when the size of the tray is 1 or 2 grid units in either the x or y direction.