### PR TITLE
feat: support gridfinitytray compatible with both laser and 3d printed bases

### DIFF
--- a/boxes/generators/gridfinitytraylayout.py
+++ b/boxes/generators/gridfinitytraylayout.py
@@ -44,6 +44,7 @@ this compartment.
         self.argparser.add_argument("--pad_radius", type=float, default=0.8, help="The corner radius for each grid opening.  Typical is 0.8,")
         self.argparser.add_argument("--cut_pads_mag_diameter", type=float, default=6.5, help="if pads are cut add holes for magnets. Typical is 6.5, zero to disable,")
         self.argparser.add_argument("--cut_pads_mag_offset", type=float, default=7.75, help="if magnet hole offset from pitch corners.  Typical is 7.75.")
+        self.argparser.add_argument("--base_thickness", type=float, default=0.0, help="the thickness of base the box will sit upon.  0 to use the material thickness, 4.65 for a standard Gridfinity 3D printed base")
         if self.UI == "web":
             self.argparser.add_argument("--layout", type=str, help="You can hand edit this before generating", default="\n");
         else:
@@ -166,7 +167,11 @@ this compartment.
             # The goal of the above code is that a stack of laser cut boxes and a stack
             # of 3d printed boxes will end up the same total height
 
-            self.h = (int(self.h[0:-1]) * 7) - self.thickness
+            self.h = (int(self.h[0:-1]) * 7)
+            if self.base_thickness == 0.0:
+                self.h -= self.thickness
+            else:
+                self.h -= self.base_thickness
 
             if self.stacking:
                 self.h += 3.69


### PR DESCRIPTION
The Gridfinity specification establishes that one height unit is 7mm, so a 6U box would be exactly 42mm high.  When a laser cut box sits on a laser cut base, the box wall height is the total height minus the thickness of the material being cut.  When a laser cut box sites on a 3D printed base, the base itself is 4.65mm (per the Gridfinity) specification so the box walls need to be shorter.

This can be seen in the following pictures:

A 6u (42mm) tall tray with stacking header (3.7mm) is a total of 45.7mm either 3d printed or laser.

![image](https://github.com/user-attachments/assets/8ea6a817-9de3-4cf1-bfa1-fe47046ad8da)

A 3d printed tray can sit on either a 3d printed base or a laser base and will still be the correct height.  However, a laser cut tray can only sit on a laser cut base and be the correct height.  If a laser cut tray is on a 3d printed base it will sit too high.

![image](https://github.com/user-attachments/assets/4ea87df8-0015-4065-b814-a324e3ded70e)

The expectation is that most users that laser cut trays are also laser cutting bases; thus, they would never experience this incompatibility.  To accomdate the case where a 3d printed base is used, this commit allows them to override the base height with a custom base height.  

![image](https://github.com/user-attachments/assets/6ff93b84-63e3-4a48-9d57-a10cd82ddee5)

This same behavior could also be accomplished without any change by specifying height in mm instead of Gridfinity units; however, for Gridfinity, it's more natural to terms of unit height is more natural.




