### PR TITLE
Add measurement labels with new label_format option

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -375,6 +375,10 @@ class Boxes:
             "--labels", action="store", type=boolarg, default=True,
             help="label the parts (where available)")
         defaultgroup.add_argument(
+            "--label_format", action="store", type=str, default="label",
+            choices=["label", "measurements", "label (measurements)"],
+            help="information to include as label on parts")
+        defaultgroup.add_argument(
             "--reference", action="store", type=float, default=100.0,
             help="print reference rectangle with given length (in mm)(zero to disable) [\U0001F6C8](https://florianfesti.github.io/boxes/html/usermanual.html#reference)")
         defaultgroup.add_argument(
@@ -444,7 +448,7 @@ class Boxes:
             else:
                 self.text(f"{self.reference:.1f}mm, burn:{self.burn:.2f}mm", self.reference / 2.0, 5,
                           fontsize=6, align="middle center", color=Color.ANNOTATIONS)
-            self.move(self.reference, 10, "up")
+            self.move(self.reference, 10, "up", label=False)
             if self.qr_code:
                 self.renderQrCode()
             self.ctx.stroke()
@@ -717,6 +721,25 @@ class Boxes:
             return [s * factor for s in l]
         except TypeError:
             return l - walls
+
+    def formatLabel(self, label: str | bool, width, height):
+        # Allows passing False to skip labeling
+        if label == False:
+            return
+
+        label_format = getattr(self, "label_format", "label")
+        measurements = f"({width:.2f}mm x {height:.2f}mm)"
+
+        if label_format == "label":
+            return label
+        elif label_format == "measurements":
+            return measurements
+        elif label_format == "label (measurements)":
+            if not label:
+                return measurements
+            return f"{label}\n{measurements}"
+        else:
+            raise ValueError("Unknown label format", label_format)
 
     def render(self):
         """Implement this method in your subclass.
@@ -1218,6 +1241,7 @@ class Boxes:
         terms = where.split()
         dontdraw = before and "only" in terms
 
+        width, height = x, y
         x += self.spacing
         y += self.spacing
 
@@ -1237,8 +1261,10 @@ class Boxes:
         if not before:
             # restore position
             self.ctx.restore()
-            if self.labels and label:
-                self.text(label, x/2, y/2, align="middle center", color=Color.ANNOTATIONS, fontsize=4)
+            if self.labels:
+                contents = self.formatLabel(label, width, height)
+                if contents:
+                    self.text(contents, x/2, y/2, align="middle center", color=Color.ANNOTATIONS, fontsize=4)
             self.ctx.stroke()
 
         for term in terms:


### PR DESCRIPTION
Adds a new label_format option that can be used to specify an option to allow for displaying measurements of a part instead of or in addition to the generators provided label. Made description the default option to preserve existing behavior.

#### Example of new behavior
![image](https://github.com/user-attachments/assets/56f91909-98e6-469a-9276-a3b0599ce752)
![image](https://github.com/user-attachments/assets/cdace2a6-955f-45cc-a51b-5c7b98a2adf2)
![image](https://github.com/user-attachments/assets/8edc4dfa-9f00-41d0-a3d1-7816a8f5a326)