### PR TITLE
Update boxes2inkscape

### DIFF
--- a/scripts/boxes2inkscape
+++ b/scripts/boxes2inkscape
@@ -121,6 +121,7 @@ class Boxes2INX:
             <submenu name="{self.groups_by_name[box.ui_group].title}"/>
         </submenu>
     </effects-menu>
+    <icon>{name}-thumb.svg</icon>
 </effect>
 <script>
     <command location="inx" interpreter="python">boxes_proxy.py</command>


### PR DESCRIPTION
add icon to let it show up in extension gallery:

![inkscape gallery](https://github.com/user-attachments/assets/1be7986c-8c02-42f4-bc90-de5190ba1aec)

as we are not allowed to use jpg in inx files, we have to wrap them into svg (see https://gitlab.com/inkscape/inbox/-/issues/?sort=created_date&state=opened&first_page_size=100&show=eyJpaWQiOiIxMjMxNSIsImZ1bGxfcGF0aCI6Imlua3NjYXBlL2luYm94IiwiaWQiOjE2ODMwNzg5Nn0%3D)

we can do this by the following one-line script (makes use if ImageMagick)

`for FILE in ~/Downloads/boxes/static/samples/*-thumb.jpg; do WIDTH=$(identify -format "%w" ${FILE}); HEIGHT=$(identify -format "%h" ${FILE}); BASENAME=$(basename -- "$FILE"); BASE_WO="${BASENAME%.*}"; echo '<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg width="'$WIDTH'" height="'$HEIGHT'" viewBox="0 0 '$WIDTH' '$HEIGHT'" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg"><g id="gimage"><image width="'$WIDTH'" height="'$HEIGHT'" xlink:href="'$BASENAME'" id="image1" /></g></svg>' > ~/Downloads/boxes/static/samples/$BASE_WO.svg; done`
