### PR TITLE
Move dev requirements to `pyproject.toml`

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .
+          pip install .[doc]
       - name: Build documentation
         run: |
           cd ./documentation/src/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ dependency is added it needs to be added in all these places:
 
 If it is a Python module it also needs to be added:
 
-* *requirements.txt* or *requirements_dev.txt*
+* *requirements.txt*
 * *pyproject.toml*
 * *documentation/src/install.rst* (unless a Python module)
 * RST files in *documentation/src/install/*

--- a/documentation/src/install.rst
+++ b/documentation/src/install.rst
@@ -12,14 +12,14 @@ Requirements
 Python
 ......
 
-Boxes.py is implemented in Python 3. For supported minor version see :code:`setup.py`.
+Boxes.py is implemented in Python 3. For supported minor version see `pyproject.toml <../../pyproject.toml>`_.
 
 Python modules
 ..............
 
 Boxes.py need a set of Python modules:
 
-.. include:: ../../requirements.txt
+.. literalinclude:: ../../requirements.txt
 
 When using a distribution the packages will typically be name be :code:`python-MODULE` or :code:`python3-MODULE`
 
@@ -36,8 +36,12 @@ Python modules for development
 
 For development (e.g. running the test suite and generating the documentation) the following modules are also needed:
 
-.. include:: ../../requirements_dev.txt
+.. literalinclude:: ../../pyproject.toml
+   :language: toml
+   :start-after: [project.optional-dependencies]
+   :end-before: [tool.setuptools.dynamic]
 
+They can be installed by :code:`pip install .[dev]` for development and :code:`pip install .[doc]` for documentation.
 
 Sphinx
 ......

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools >= 63.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-dynamic = ["dependencies", "optional-dependencies"]
+dynamic = ["dependencies"]
 name = 'boxes'
 version = '1.2'
 requires-python = '>=3.9'
@@ -23,9 +23,18 @@ classifiers = [ # https://pypi.python.org/pypi?%3Aaction=list_classifiers
   "Topic :: Scientific/Engineering",
 ]
 
+[project.optional-dependencies]
+dev = [
+  "lxml",
+  "mypy",
+  "pre-commit",
+  "pytest>=8.1.1",
+  "types-Markdown"
+]
+doc = ["sphinx>=8.0.2"]
+
 [tool.setuptools.dynamic]
 dependencies = {file=["requirements.txt"]}
-optional-dependencies = {dev = { file = ["requirements_dev.txt"] }}
 
 [project.scripts]
 boxes = 'boxes.scripts.boxes_main:main'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ markdown
 qrcode>=7.3.1
 setuptools
 shapely>=1.8.2
-sphinx

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,0 @@
-lxml
-mypy
-pre-commit
-pytest>=8.1.1
-types-Markdown


### PR DESCRIPTION
## Changes

- Move dev requirements to `pyproject.toml`
- Add dependencies for documentation
- Dependency `sphinx` is not required to run boxes
- Remove `requirements_dev.txt`
- Update documentation about requirements