### PR TITLE
added missing qrcode dependency in mac docs

### DIFF
--- a/documentation/src/install/macos.rst
+++ b/documentation/src/install/macos.rst
@@ -31,7 +31,7 @@ General
 
    .. code::
 
-      pip3 install Markdown affine shapely
+      pip3 install Markdown affine shapely qrcode
 
 4. Download Boxes.py via Git:
 


### PR DESCRIPTION
I just added 'qrcode' library to list of dependencies (for MacOS install).

(First contribution, trying to see if I followed everything ok)