### PR TITLE
Added `spacing` argument to allow to set the spacing between parts.

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -384,14 +384,14 @@ class Boxes:
         defaultgroup.add_argument(
             "--burn", action="store", type=float, default=0.1,
             help='burn correction (in mm)(bigger values for tighter fit) [\U0001F6C8](https://florianfesti.github.io/boxes/html/usermanual.html#burn)')
-        def space_type(x):
+        def spacing_type(x):
             try:
                 return (float(x), 0.)
             except ValueError:
                 return tuple(float(v.strip()) for v in x.split(":"))
         defaultgroup.add_argument(
-            "--space", action="store", type=space_type, default="0.5",
-            help='space around parts (multiples of thickness [: extra space in mm]) [\U0001F6C8](https://florianfesti.github.io/boxes/html/usermanual.html#spacing)')
+            "--spacing", action="store", type=spacing_type, default="0.5",
+            help='spacing around parts (multiples of thickness [: extra space in mm]) [\U0001F6C8](https://florianfesti.github.io/boxes/html/usermanual.html#spacing)')
 
     @contextmanager
     def saved_context(self):
@@ -440,7 +440,7 @@ class Boxes:
             self.ctx.set_line_width(max(2 * self.burn, 0.05))
             self.set_source_color(Color.BLACK)
 
-        self.spacing = 2 * self.burn + self.space[0] * self.thickness + self.space[1]
+        self.spacing = 2 * self.burn + self.spacing[0] * self.thickness + self.spacing[1]
         self.set_font("sans-serif")
         self._buildObjects()
         if self.reference and self.format != 'svg_Ponoko':

--- a/documentation/src/usermanual.rst
+++ b/documentation/src/usermanual.rst
@@ -87,10 +87,10 @@ much smaller it is than its nominal size. The burn value should be
 around half of the difference. To test the fit for several values at
 once you can use the **BurnTest** generator in the "Parts and Samples" section.
 
-space
-.....
+spacing
+.......
 
-The space parameter defines the spacing between parts.
+The spacing parameter defines the spacing between parts.
 
 It is given in multiples of the material thickness (default: 0.5).
 An optional absolute offset in millimetres can be appended after a colon.


### PR DESCRIPTION
This patch allows the user to modify the spacing between parts.

### Motivation
I am using LightBurn and use its kerf feature, so I usually set *burn* to 0 and export to lbrn2 format.
As I am using the "Remove overlapping lines" feature (with distance at least the size of the kerf) of LightBurn and usually place my parts one kerf from each other so that parallel edges are only cut once. With the default spacing of half a thickness I always need to adjust the placement manually.

This addition allows for the original default spacing but also to adjust it according to the thickness *and* also add an extra absolute amount.

I myself would set *burn* to 0 and *space* to `0 : 0.125` where 0.125 is my kerf. This places all part one kerf apart and LightBurn removes parallel edges, reducing the burn time and reduces material waste.