### PR TITLE
Add line width argument for SVG preview and export

### DIFF
--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -408,6 +408,9 @@ class Boxes:
         defaultgroup.add_argument(
             "--output", action="store", type=str, default="box.svg",
             help="name of resulting file")
+        defaultgroup.add_argument(
+            "--line_width", action="store", type=(lambda x: float('NaN') if x == "" else float(x)), default="",
+            help='line width for SVG preview and export (in mm) (default: 2x burn but at least 0.05) [\U0001F6C8](https://florianfesti.github.io/boxes/html/usermanual.html#line-width)')
         def spacing_type(x):
             try:
                 return (float(x), 0.)
@@ -464,7 +467,10 @@ class Boxes:
             self.ctx.set_line_width(0.01)
             self.set_source_color(Color.BLUE)
         else:
-            self.ctx.set_line_width(max(2 * self.burn, 0.05))
+            line_width = self.line_width
+            if line_width != line_width:  # check for NaN (default)
+                line_width = max(2 * self.burn, 0.05)
+            self.ctx.set_line_width(line_width)
             self.set_source_color(Color.BLACK)
 
         self.spacing = 2 * self.burn + self.spacing[0] * self.thickness + self.spacing[1]

--- a/documentation/src/usermanual.rst
+++ b/documentation/src/usermanual.rst
@@ -87,6 +87,14 @@ much smaller it is than its nominal size. The burn value should be
 around half of the difference. To test the fit for several values at
 once you can use the **BurnTest** generator in the "Parts and Samples" section.
 
+line_width
+..........
+
+The line width parameter defines how wide the lines in the SVG preview
+and download files are drawn. By default it is twice the burn value but
+at least 0.05mm. This paramteter allows to overwrite if required by some
+laser engraving software.
+
 spacing
 .......
 


### PR DESCRIPTION
This PR implements a line width argument which allows the setting of the SVG line with independent of the burn parameter.
This was requested originally by #607 as the user there seems to use a laser engraving software which needs a line width of 0.001mm for burning but engraves thicker lines instead. The current implementation enforces a minimum of 0.05mm.

I also like to set the burn parameter to 0 and use LigthBurn's kerf offset setting instead, but find the 0.05mm minimum hard to view on the SVG preview. I therefore would also like to see such a parameter.

I implemented it in a way, that the value is an empty string by default and then follows the original value of min(2x burn, 0.05) making the change fully backward compatible.

Fixes #607.