### PR TITLE
Added symlinks to pre-commit excludes to avoid issues with missing trailing spaces under Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 ci:
   autofix_prs: true
   autoupdate_schedule: quarterly
-exclude: '\.svg$'
+exclude: '^(documentation/src/static|scripts/boxes|scripts/boxes_proxy.py|scripts/boxesserver|.*\.svg)$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
Follow-up to PR _Added missing new lines reported by pre-commit hook_ #841.

This minor issue can be fixed to exclude the symlink files from the pre-commit check.