### PR TITLE
chore: drop EOL py3.9; test new py3.14

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip" # caching pip dependencies
       - name: Install dependencies
         run: |

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.13" ] # Lowest and highest.
+        python-version: [ "3.10", "3.14" ] # Lowest and highest.
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 exclude: '^(documentation/src/static|scripts/boxes|scripts/boxes_proxy.py|scripts/boxesserver|.*\.svg)$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -32,10 +32,10 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.0
     hooks:
       - id: pyupgrade
-        args: [ --py39-plus ]
+        args: [ --py310-plus ]
 
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1
@@ -44,7 +44,7 @@ repos:
         args: [ --remove-all-unused-imports, --in-place, --ignore-pass-statements, ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.1
+    rev: v1.18.2
     hooks:
       - id: mypy
         files: '^boxes/.*\.py$'
@@ -65,7 +65,7 @@ repos:
         additional_dependencies: [ sphinx ]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 

--- a/boxes/lids.py
+++ b/boxes/lids.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import boxes
 from boxes import Boxes, edges

--- a/boxes/parts.py
+++ b/boxes/parts.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from math import *
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 from boxes import vectors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 dynamic = ["dependencies"]
 name = 'boxes'
 version = '1.2'
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 description = 'Boxes generator for laser cutters'
 maintainers = [ { name = 'Florian Festi', email='florian@festi.info' } ]
 readme = "README.rst"


### PR DESCRIPTION
Just some chore:

- drop EOL py3.9; test new py3.14
- Update pre-commit dependencies.