### PR TITLE
Made autorestart of boxesserver work under MS Windows

### DIFF
--- a/boxes/scripts/boxesserver.py
+++ b/boxes/scripts/boxesserver.py
@@ -75,7 +75,7 @@ class FileChecker(threading.Thread):
     def run(self) -> None:
         while not self._stopped:
             if not self.filesOK():
-                os.execv(__file__, sys.argv)
+                os.execl(sys.executable, 'python', __file__, *sys.argv[1:])
             time.sleep(1)
 
     def stop(self) -> None:


### PR DESCRIPTION
With the current implementation the autorestart code uses the script file itself as executable.
This fails under Windows as the script is not a Windows executable.

This PR changes the restart command to use the python executable instead with the script name as an argument.

Tested under MS Windows. Please test under Linux before merge.