### PR TITLE
Fix artefacts in LaserHoldfast outline due to corner overcorrections

### DIFF
--- a/boxes/generators/laserholdfast.py
+++ b/boxes/generators/laserholdfast.py
@@ -69,20 +69,22 @@ class LaserHoldfast(Boxes):
 
         a = 30
         r = x/math.radians(a)
-        dd = hh - hh * math.cos(math.radians(a/2))
+        dd = hh - hh * math.cos(math.radians(a/2)) + self.burn
 
         # Hook
         self.polygonWall(
-            (
+            [
                 hh + h - dd, (180, sw / 2),
-                h, -90 + a / 2,
+                h, (-90 + a / 2, self.burn),
                 0, (-a, r),
                 0, (180, hh / 2),
                 0, (a, r + hh),
-                0, -a / 2,
-                sw - math.sin(math.radians(a / 2)) * hh, 90,
-            ),
+                0, (-a / 2, self.burn),
+                sw - math.sin(math.radians(a / 2)) * hh + self.burn/2, 0,
+                None
+            ],
             edge='e',
+            correct_corners=False,
             move=move,
             callback=self.cutcallback if self.cutlength else None
         )

--- a/examples/LaserHoldfast.svg
+++ b/examples/LaserHoldfast.svg
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<svg height="64.67mm" viewBox="0.0 0.0 120.00 64.67" width="120.00mm" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg height="64.75mm" viewBox="0.0 0.0 120.00 64.75" width="120.00mm" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <!--
 LaserHoldfast - A holdfast for honey comb tables of laser cutters
 
@@ -19,10 +19,10 @@ Command line short: boxes LaserHoldfast
 </dc:description>
 </cc:Work></rdf:RDF></metadata>
 <g id="p-0" style="fill:none;stroke-linecap:round;stroke-linejoin:round;">
-  <path d="M 10.000 54.674 H 110.000 V 44.674 H 10.000 V 54.674 Z" stroke="rgb(0,0,0)" stroke-width="0.20" />
-  <text dominant-baseline="hanging" font-size="6px" style="font-family: sans-serif ; font-weight: normal; font-style: normal; fill: rgb(255,0,0)" text-anchor="middle" transform="matrix( 1.000 0.000 0.000 1.000 60.000 46.674 )">100.0mm, burn:0.10mm</text>
+  <path d="M 10.000 54.750 H 110.000 V 44.750 H 10.000 V 54.750 Z" stroke="rgb(0,0,0)" stroke-width="0.20" />
+  <text dominant-baseline="hanging" font-size="6px" style="font-family: sans-serif ; font-weight: normal; font-style: normal; fill: rgb(255,0,0)" text-anchor="middle" transform="matrix( 1.000 0.000 0.000 1.000 60.000 46.750 )">100.0mm, burn:0.10mm</text>
 </g>
 <g id="p-1" style="fill:none;stroke-linecap:round;stroke-linejoin:round;">
-  <path d="M 11.797 42.974 H 56.627 C 57.083 42.974 57.532 42.854 57.927 42.626 C 58.322 42.397 58.650 42.069 58.879 41.674 C 59.107 41.279 59.227 40.830 59.227 40.374 C 59.227 39.917 59.107 39.469 58.879 39.074 C 58.650 38.679 58.322 38.350 57.927 38.122 C 57.532 37.894 57.083 37.774 56.627 37.774 H 18.929 H 16.704 C 16.627 37.774 16.724 37.848 16.704 37.774 L 16.128 35.624 L 16.724 37.848 C 14.559 29.769 14.559 21.263 16.724 13.184 C 16.842 12.743 16.842 12.279 16.724 11.838 C 16.605 11.398 16.373 10.996 16.051 10.673 C 15.728 10.350 15.326 10.118 14.885 10.000 C 14.444 9.882 13.980 9.882 13.539 10.000 C 13.098 10.118 12.696 10.350 12.374 10.673 C 12.051 10.996 11.819 11.398 11.701 11.838 C 9.300 20.799 9.300 30.233 11.701 39.194 L 11.598 38.812 L 11.697 39.181 C 11.701 39.194 11.697 39.168 11.697 39.181 V 39.563 V 42.874 C 11.697 42.929 11.742 42.974 11.797 42.974 Z" stroke="rgb(0,0,0)" stroke-width="0.20" />
+  <path d="M 11.994 43.048 H 56.724 C 57.180 43.048 57.628 42.928 58.024 42.700 C 58.419 42.471 58.747 42.143 58.975 41.748 C 59.203 41.353 59.324 40.904 59.324 40.448 C 59.324 39.992 59.203 39.543 58.975 39.148 C 58.747 38.753 58.419 38.425 58.024 38.196 C 57.628 37.968 57.180 37.848 56.724 37.848 H 16.724 C 14.559 29.769 14.559 21.263 16.724 13.184 C 16.842 12.743 16.842 12.279 16.724 11.838 C 16.605 11.398 16.373 10.996 16.051 10.673 C 15.728 10.350 15.326 10.118 14.885 10.000 C 14.444 9.882 13.980 9.882 13.539 10.000 C 13.098 10.118 12.696 10.350 12.374 10.673 C 12.051 10.996 11.819 11.398 11.701 11.838 C 9.300 20.799 9.300 30.233 11.701 39.194 V 42.950 C 11.701 43.005 11.746 43.050 11.802 43.050 L 11.995 43.048 C 11.994 43.048 11.994 43.048 11.994 43.048 Z" stroke="rgb(0,0,0)" stroke-width="0.20" />
 </g>
 </svg>


### PR DESCRIPTION
This PR fixes some drawing artefacts done by `polygonWall()` corner correction as well as by the added `burn` radius in some corners.

Before the hook had some larger extra lines in its start and end corners:

<img width="1001" height="697" alt="LaserHoldfast_before" src="https://github.com/user-attachments/assets/6c8ed5d6-59a2-4ae1-b4a3-67262f0df788" />

* This can be largely avoided by using `correct_corners=False` to avoid overcorrections for these difficult corners. 
* Then some negative arcs with the `burn` radius appear (due to `self.burn - radius` in `Boxes.corner()` while `radius=0`), so a radius with `self.burn` is added to get a proper, zero corner. 
* This however makes the lines not meet at the end, so some other length where adjusted and `None` was added to make `polygonWall()` autoclose the path. The result has some extra points for the autoclosing then, which seem to be acceptable and not easily avoidable.

After:
<img width="1012" height="698" alt="LaserHoldfast_after" src="https://github.com/user-attachments/assets/b6d11d4b-5c5a-4e8e-8cc8-2c792ed44127" />

