### PR TITLE
Fixed ignore message pattern to support message format in newer rstcheck versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,5 +67,5 @@ ignore_directives = [
   "automodule",
 ]
 ignore_messages = [
-  "File referenced in \"include\" directive not found: 'generators.inc'",
+  "File referenced in \"include\" directive not found: '.*generators\\.inc'",
 ]


### PR DESCRIPTION
Newer `rstcheck` version output the full path of missing include files, no longer just the filename.
The `ignore_messages` pattern must be updated in order to match again otherwise `pre-commit` checks of all PRs will fail.

Fixes #943.