### PR TITLE
Update nix flake to include imagemagick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tracker.log
 *.isorted
 .DS_Store
 .venv/
+flake.lock

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,11 @@
           default = pkgs.mkShell {
             packages = [
               python
-              pkgs.pre-commit
               pkgs.git
+              # optional: needed for thumbnail generation
+              pkgs.imagemagick
+              # optional: needed for pre-commit hook
+              pkgs.pre-commit
               # optional: needed only for non-SVG output (dxf, plt/hpgl, gcode, ps->pdf)
               pkgs.pstoedit
               pkgs.ghostscript


### PR DESCRIPTION
When creating the nix flake file yesterday, I missed the dependency on `imagemagick` for thumbnail generation. This adds it.

Also adds the `flake.lock` file resulting from using the devshell to `.gitignore`.