### PR TITLE
feat: add lint tool `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,16 @@ repos:
       - id: autoflake
         args: [ --remove-all-unused-imports, --in-place, --ignore-pass-statements, ]
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.4
+    hooks:
+      - id: ruff-check
+        types_or: [ python, pyproject ]
+        args: [ --fix ]
+      #- id: ruff-format
+
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.1
     hooks:
       - id: mypy
         name: mypy - boxes
@@ -64,18 +72,18 @@ repos:
         files: '^setup.py$'
 
   - repo: https://github.com/rstcheck/rstcheck
-    rev: v6.2.5
+    rev: v6.3.0
     hooks:
       - id: rstcheck
         additional_dependencies: [ 'rstcheck[sphinx,toml]' ]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: v0.11.0.1-1
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         exclude: ^(locale|po|static)/

--- a/boxes/__init__.py
+++ b/boxes/__init__.py
@@ -254,14 +254,12 @@ class ArgparseEdgeType:
 
     def html(self, name, default, translate):
         options = "\n".join(
-            """<option value="%s"%s>%s</option>""" %
-             (e, ' selected="selected"' if e == default else "",
+            """<option value="{}"{}>{}</option>""".format(e, ' selected="selected"' if e == default else "",
               translate("{} {}".format(e, self.names.get(e, "")))) for e in self.edges)
         return """<select name="{}" id="{}" aria-labeledby="{} {}" size="1">\n{}</select>\n""".format(name,  name, name+"_id", name+"_description", options)
 
     def inx(self, name, viewname, arg):
-        return ('        <param name="%s" type="optiongroup" appearance="combo" gui-text="%s" gui-description=%s>\n' %
-                (name, viewname, quoteattr(arg.help or "")) +
+        return ('        <param name="{}" type="optiongroup" appearance="combo" gui-text="{}" gui-description={}>\n'.format(name, viewname, quoteattr(arg.help or "")) +
                 ''.join('            <option value="{}">{} {}</option>\n'.format(
                     e, e, self.names.get(e, ""))
                          for e in self.edges) +
@@ -276,9 +274,8 @@ class BoolArg:
     def html(self, name, default, _):
         if isinstance(default, (str)):
             default = self(default)
-        return """<input name="%s" type="hidden" value="0">
-<input name="%s" id="%s" aria-labeledby="%s %s" type="checkbox" value="1"%s>""" % \
-            (name, name, name, name+"_id", name+"_description",' checked="checked"' if default else "")
+        return """<input name="{}" type="hidden" value="0">
+<input name="{}" id="{}" aria-labeledby="{} {}" type="checkbox" value="1"{}>""".format(name, name, name, name+"_id", name+"_description",' checked="checked"' if default else "")
 
 boolarg = BoolArg()
 
@@ -1558,7 +1555,7 @@ class Boxes:
                 else:
                     self.moveTo(0, moves[a])
             else:
-                raise ValueError("Unknown alignment: %s" % align)
+                raise ValueError(f"Unknown alignment: {align}")
 
         for line in reversed(text):
             self.ctx.show_text(line, fs=fontsize, align=halign, rgb=color, font=font)
@@ -1737,7 +1734,7 @@ class Boxes:
             n = 8
             a = 22.5
         else:
-            raise ValueError("fillHoles - unknown hole style: %s)" % style)
+            raise ValueError(f"fillHoles - unknown hole style: {style})")
 
 # note to myself: ^y  x>
 
@@ -2038,7 +2035,7 @@ class Boxes:
                                 segment_max = 0
                 y += step_y
         else:
-           raise ValueError("fillHoles - unknown hole pattern: %s)" % pattern)
+           raise ValueError(f"fillHoles - unknown hole pattern: {pattern})")
 
     def hexHolesRectangle(self, x, y, settings=None, skip=None):
         """Fills a rectangle with holes in a hex pattern.

--- a/boxes/edges.py
+++ b/boxes/edges.py
@@ -658,7 +658,7 @@ class GroovedEdgeBase(BaseEdge):
                 angle = self.settings.tri_angle
                 self.groove_triangle(width, angle, inv)
             else:
-                raise ValueError("Unknown GroovedEdge style: %s)" % style)
+                raise ValueError(f"Unknown GroovedEdge style: {style})")
 
         # The final edge
         self.edge(margin, tabs=1)
@@ -1359,7 +1359,7 @@ class Hinge(BaseEdge):
         super().__init__(boxes, settings)
 
         if not (0 < layout <= 3):
-            raise ValueError("layout must be 1, 2 or 3 (got %i)" % layout)
+            raise ValueError(f"layout must be 1, 2 or 3 (got {layout})")
 
         self.layout = layout
         self.char = "eijk"[layout]
@@ -1455,7 +1455,7 @@ class HingePin(BaseEdge):
         super().__init__(boxes, settings)
 
         if not (0 < layout <= 3):
-            raise ValueError("layout must be 1, 2 or 3 (got %i)" % layout)
+            raise ValueError(f"layout must be 1, 2 or 3 (got {layout})")
 
         self.layout = layout
         self.char = "EIJK"[layout]

--- a/boxes/formats.py
+++ b/boxes/formats.py
@@ -97,7 +97,7 @@ class Formats:
 
                     if result.returncode:
                         # XXX show stderr output
-                        raise ValueError("Conversion failed. pstoedit returned %i\n\n %s" % (result.returncode, result.stderr))
+                        raise ValueError(f"Conversion failed. pstoedit returned {result.returncode}\n\n {result.stderr}")
                     with open(outfile, 'rb') as ff:
                         data = io.BytesIO(ff.read())
                 finally:

--- a/boxes/gears.py
+++ b/boxes/gears.py
@@ -395,7 +395,7 @@ class Gears:
         elif self.options.system == 'MM': # module (metric)
             circular_pitch = pi * dimension
         else:
-            raise ValueError("unknown system '%s', try CP, DP, MM" % self.options.system)
+            raise ValueError(f"unknown system '{self.options.system}', try CP, DP, MM")
 
         # circular_pitch defines the size in mm
         return circular_pitch
@@ -632,7 +632,7 @@ class Gears:
             min_teeth = ceil(undercut_min_teeth(angle, 1.0))
             min_angle = undercut_min_angle(teeth, 1.0) + .1
             max_k = undercut_max_k(teeth, angle)
-            msg = "Undercut Warning: This gear (%d teeth) will not work well.\nTry tooth count of %d or more,\nor a pressure angle of %.1f [deg] or more,\nor try a profile shift of %d %%.\nOr other decent combinations." % (teeth, min_teeth, min_angle, int(100.*max_k)-100.)
+            msg = f"Undercut Warning: This gear ({teeth} teeth) will not work well.\nTry tooth count of {min_teeth} or more,\nor a pressure angle of {min_angle:.1f} [deg] or more,\nor try a profile shift of {int(100. * max_k) - 100.} %.\nOr other decent combinations."
             # alas annotation cannot handle the degree symbol. Also it ignore newlines.
             # so split and make a list
             warnings.extend(msg.split("\n"))
@@ -685,15 +685,15 @@ class Gears:
 
             notes = []
             notes.extend(warnings)
-            #notes.append('Document (%s) scale conversion = %2.4f' % (self.document.getroot().find(inkex.addNS('namedview', 'sodipodi')).get(inkex.addNS('document-units', 'inkscape')), unit_factor))
-            notes.extend(['Teeth: %d   CP: %2.4f(%s) ' % (teeth, pitch / unit_factor, self.options.units),
+            # notes.append('Document ({}) scale conversion = {:2.4f}'.format(self.document.getroot().find(inkex.addNS('namedview', 'sodipodi')).get(inkex.addNS('document-units', 'inkscape')), unit_factor))
+            notes.extend([f'Teeth: {teeth}   CP: {pitch / unit_factor:2.4f}({self.options.units}) ',
                           f'DP: {25.4 * pi / pitch:2.3f} Module: {pitch:2.4f}(mm)',
-                          'Pressure Angle: %2.2f degrees' % (angle),
+                          f'Pressure Angle: {angle:2.2f} degrees',
                           f'Pitch diameter: {pitch_radius * 2 / unit_factor:2.3f} {self.options.units}',
                           f'Outer diameter: {outer_dia / unit_factor:2.3f} {self.options.units}',
-                          f'Base diameter:  {base_radius * 2 / unit_factor:2.3f} {self.options.units}'#,
-                          #'Addendum:      %2.4f %s'  % (addendum / unit_factor, self.options.units),
-                          #'Dedendum:      %2.4f %s'  % (dedendum / unit_factor, self.options.units)
+                          f'Base diameter:  {base_radius * 2 / unit_factor:2.3f} {self.options.units}',
+                          # f'Addendum:      {addendum / unit_factor:2.4f} {self.options.units}',
+                          # f'Dedendum:      {dedendum / unit_factor:2.4f} {self.options.units}',
                           ])
             # text height relative to gear size.
             # ranges from 10 to 22 over outer radius size 60 to 360

--- a/boxes/generators/burntest.py
+++ b/boxes/generators/burntest.py
@@ -90,7 +90,7 @@ See also LBeam that can serve as compact BurnTest and FlexTest for testing flex 
 
         for cnt in range(self.pairs):
             for i in range(4):
-                self.text("%.3fmm" % self.burn, x / 2, t, **font)
+                self.text(f"{self.burn:.3f}mm", x / 2, t, **font)
                 if self.date and i == 3:
                     self.text(today, x / 2, 20, **font_meta)
                 if self.id and i == 1:
@@ -103,7 +103,7 @@ See also LBeam that can serve as compact BurnTest and FlexTest for testing flex 
             self.moveTo(x + 2 * t + self.spacing, -t)
 
             for i in range(4):
-                self.text("%.3fmm" % self.burn, x / 2, t, **font)
+                self.text(f"{self.burn:.3f}mm", x / 2, t, **font)
                 if self.date and i == 3:
                     self.text(today, x / 2, 20, **font_meta)
                 if self.id and i == 1:

--- a/boxes/generators/desksign.py
+++ b/boxes/generators/desksign.py
@@ -78,7 +78,7 @@ Empty lines will affect the placement."""
 
         if label and fontsize:
             self.rectangularWall(width, height, "eheh", move="right", callback=[
-                lambda: self.text("%s" % label, width/2, height/2 + verticaltextoffset,
+                lambda: self.text(f"{label}", width/2, height/2 + verticaltextoffset,
                     fontsize = fontsize, align="middle center", color=Color.ETCHING)]) # add text
         else:
             self.rectangularWall(width, height, "eheh", move="right") # front

--- a/boxes/generators/discrack.py
+++ b/boxes/generators/discrack.py
@@ -169,10 +169,10 @@ class DiscRack(Boxes):
                 return "absent"
 
         if self.rear_outset < self.thickness:
-            warnings.append("Rear upper constraint is %s. Consider increasing the disc outset parameter, or move the angle away from 45°." % word_thickness(self.rear_outset))
+            warnings.append(f"Rear upper constraint is {word_thickness(self.rear_outset)}. Consider increasing the disc outset parameter, or move the angle away from 45°.")
 
         if self.lower_outset < self.thickness:
-            warnings.append("Lower front constraint is %s. Consider increasing the disc outset parameter, or move the angle away from 45°." % word_thickness(self.lower_outset))
+            warnings.append(f"Lower front constraint is {word_thickness(self.lower_outset)}. Consider increasing the disc outset parameter, or move the angle away from 45°.")
 
         # Are the discs supported where the grids meet?
 

--- a/boxes/generators/drillbox.py
+++ b/boxes/generators/drillbox.py
@@ -81,7 +81,7 @@ class DrillBox(_TopEdge):
                 if description:
                     self.rectangularHole(x + dx / 2, y + dy / 2, dx - 2, dy - 2, color=Color.ETCHING)
                     self.text(
-                        "%.1f" % d,
+                        f"{d:.1f}",
                         x + 2,
                         y + 2,
                         270,

--- a/boxes/generators/edges.py
+++ b/boxes/generators/edges.py
@@ -29,5 +29,4 @@ class Edges(Boxes):
         self._buildObjects()
         chars = self.edges.keys()
         for c in sorted(chars, key=lambda x:(x.lower(), x.isupper())):
-            print("%s %s - %s" %(c, self.edges[c].__class__.__name__,
-                  self.edges[c].__doc__))
+            print(f"{c} {self.edges[c].__class__.__name__} - {self.edges[c].__doc__}")

--- a/boxes/generators/frameloom.py
+++ b/boxes/generators/frameloom.py
@@ -103,8 +103,8 @@ piece pull together as you weave.
                         - math.degrees(math.atan2(_b, _a)))
         if not 0.0 < pin_flare <= 90.0:
             raise ValueError(
-                "pin_width %.3f is out of range; supported range is 2.0 to 5.5 mm "
-                "for the current pin shape constants" % pin_width)
+                f"pin_width {pin_width:.3f} is out of range; supported range is 2.0 to 5.5 mm "
+                "for the current pin shape constants")
 
         def drawPin():
             # Tapered spike, exactly pin_width wide at the frame edge.

--- a/boxes/generators/piratechest.py
+++ b/boxes/generators/piratechest.py
@@ -49,12 +49,12 @@ class PirateChest(Boxes):
         n = self.n
 
         if (n < 3):
-            raise ValueError("number of sides on the lid must be greater or equal to 3 (got %i)" % n)
+            raise ValueError(f"number of sides on the lid must be greater or equal to 3 (got {n})")
 
         hy = self.edges["O"].startWidth()
         h -= hy
         if (h < 0):
-            raise ValueError("box to low to allow for hinge (%i)" % h)
+            raise ValueError(f"box to low to allow for hinge ({h})")
 
         # create edge for non 90 degree joints in the lid
         fingerJointSettings = copy.deepcopy(self.edges["f"].settings)

--- a/boxes/generators/planetary2.py
+++ b/boxes/generators/planetary2.py
@@ -205,4 +205,4 @@ class Planetary2(Boxes):
                        angle=pressure_angle,
                        profile_shift=profile_shift, move="up only")
 
-        self.text("1:%.1f" % abs(ratio))
+        self.text(f"1:{abs(ratio):.1f}")

--- a/boxes/generators/robotarm.py
+++ b/boxes/generators/robotarm.py
@@ -30,26 +30,26 @@ class RobotArm(Boxes): # change class name here and below
             ra = robot.RobotArg(True)
             sa = servos.ServoArg()
             self.argparser.add_argument(
-                "--type%i" % i,  action="store", type=ra,
+                f"--type{i}", action="store", type=ra,
                 default="none", choices=ra.choices(),
                 help="type of arm segment")
             self.argparser.add_argument(
-                "--servo%ia" % i,  action="store", type=sa, default="Servo9g",
+                f"--servo{i}a", action="store", type=sa, default="Servo9g",
                 choices=sa.choices(), help="type of servo to use")
             self.argparser.add_argument(
-                "--servo%ib" % i,  action="store", type=sa, default="Servo9g",
+                f"--servo{i}b", action="store", type=sa, default="Servo9g",
                 choices=sa.choices(), help="type of servo to use on second side (if different is supported)")
             self.argparser.add_argument(
-                "--length%i" % i,  action="store", type=float, default=50.,
+                f"--length{i}", action="store", type=float, default=50.,
                 help="length of segment axle to axle")
 
     def render(self):
 
         for i in range(5, 0,-1):
-            armtype = getattr(self, "type%i" % i)
-            length = getattr(self, "length%i" % i)
-            servoA = getattr(self, "servo%ia" % i)
-            servoB = getattr(self, "servo%ib" % i)
+            armtype = getattr(self, f"type{i}")
+            length = getattr(self, f"length{i}")
+            servoA = getattr(self, f"servo{i}a")
+            servoB = getattr(self, f"servo{i}b")
             armcls = getattr(robot, armtype, None)
             if not armcls:
                 continue

--- a/boxes/generators/traylayout.py
+++ b/boxes/generators/traylayout.py
@@ -71,11 +71,11 @@ The actual sizes and all other settings can be entered in the second step."""
         r = []
 
         for i, x in enumerate(self.sx):
-            r.append(" |" * i + " ,> %.1fmm\n" % x)
+            r.append(" |" * i + f" ,> {x:.1f}mm\n")
 
         for hwalls, vwalls, floors, y in zip(self.hwalls, self.vwalls, self.floors, self.sy):
             r.append("".join("+" + " -"[h] for h in hwalls) + "+\n")
-            r.append("".join((" |"[v] + "X "[f] for v, f in zip(vwalls, floors))) + " |"[vwalls[-1]] + " %.1fmm\n" % y)
+            r.append("".join((" |"[v] + "X "[f] for v, f in zip(vwalls, floors))) + " |"[vwalls[-1]] + f" {y:.1f}mm\n")
         r.append("".join("+" + " -"[h] for h in self.hwalls[-1]) + "+\n")
 
         return "".join(r)
@@ -486,20 +486,20 @@ to remove the floor for this compartment.
                         elif c == ' ':
                             f.append(True)
                         else:
-                            raise ValueError("""Can't parse line %i in layout: expected " ", "x" or "X" for char #%i""" % (nr + 1, n + 1))
+                            raise ValueError(f"""Can't parse line {nr + 1} in layout: expected " ", "x" or "X" for char #{n + 1}""")
                     else:
                         if c == ' ':
                             w.append(False)
                         elif c == '|':
                             w.append(True)
                         else:
-                            raise ValueError("""Can't parse line %i in layout: expected " ", or "|" for char #%i""" % (nr + 1, n + 1))
+                            raise ValueError(f"""Can't parse line {nr + 1} in layout: expected " ", or "|" for char #{n + 1}""")
 
                 floors.append(f)
                 vwalls.append(w)
                 m = re.match(r"([ |][ xX])+[ |]\s*(\d*\.?\d+)\s*mm\s*", line)
                 if not m:
-                    raise ValueError("""Can't parse line %i in layout: Can read height of the row""" % (nr + 1))
+                    raise ValueError(f"""Can't parse line {nr + 1} in layout: Can read height of the row""")
                 else:
                     y.append(float(m.group(2)))
 
@@ -512,15 +512,15 @@ to remove the floor for this compartment.
         if ly == 0:
             raise ValueError("Need more than one wall in y direction")
         if len(hwalls) != ly + 1:
-            raise ValueError("Wrong number of horizontal wall lines: %i (%i expected)" % (len(hwalls), ly + 1))
+            raise ValueError(f"Wrong number of horizontal wall lines: {len(hwalls)} ({ly + 1} expected)")
         for nr, walls in enumerate(hwalls):
             if len(walls) != lx:
-                raise ValueError("Wrong number of horizontal walls in line %i: %i (%i expected)" % (nr, len(walls), lx))
+                raise ValueError(f"Wrong number of horizontal walls in line {nr}: {len(walls)} ({lx} expected)")
         if len(vwalls) != ly:
-            raise ValueError("Wrong number of vertical wall lines: %i (%i expected)" % (len(vwalls), ly))
+            raise ValueError(f"Wrong number of vertical wall lines: {len(vwalls)} ({ly} expected)")
         for nr, walls in enumerate(vwalls):
             if len(walls) != lx + 1:
-                raise ValueError("Wrong number of vertical walls in line %i: %i (%i expected)" % (nr, len(walls), lx + 1))
+                raise ValueError(f"Wrong number of vertical walls in line {nr}: {len(walls)} ({lx + 1} expected)")
 
         self.x = x
         self.y = y

--- a/boxes/generators/typetray.py
+++ b/boxes/generators/typetray.py
@@ -197,7 +197,7 @@ class TypeTray(_TopEdge):
 
             # Generate text
             self.text(
-                "%s" % self.textcontent[self.textnumber],
+                f"{self.textcontent[self.textnumber]}",
                 textx,
                 texty,
                 0,

--- a/boxes/generators/unevenheightbox.py
+++ b/boxes/generators/unevenheightbox.py
@@ -55,7 +55,7 @@ class UnevenHeightBox(Boxes):
 
         edge_types = self.edge_types
         if len(edge_types) != 4 or any(et not in "ezZ" for et in edge_types):
-            raise ValueError("Wrong edge_types style: %s)" % edge_types)
+            raise ValueError(f"Wrong edge_types style: {edge_types})")
 
         if self.outside:
             x = self.adjustSize(x)

--- a/boxes/robot.py
+++ b/boxes/robot.py
@@ -24,8 +24,7 @@ class RobotArg:
 
     def html(self, name, default, translate):
         options = "\n".join(
-            ("""<option value="%s"%s>%s %s</option>""" %
-             (name, ' selected="selected"' if name == default else "",
+            ("""<option value="{}"{}>{} {}</option>""".format(name, ' selected="selected"' if name == default else "",
               name, descr) for name, descr in self.robotarms))
         return f"""<select name="{name}" size="1">\n{options}</select>\n"""
 

--- a/boxes/scripts/boxes_generator.py
+++ b/boxes/scripts/boxes_generator.py
@@ -192,7 +192,7 @@ def generate(cut, output_prefix, format="svg"):
             raise ValueError("box_type must be provided for each cut")
         box_cls = GENERATORS.get(box_type, None)
         if box_cls is None:
-            raise ValueError("invalid generator '%s'" % box_type)
+            raise ValueError(f"invalid generator '{box_type}'")
 
         # Instantitate the box object
         box = box_cls()

--- a/boxes/scripts/boxes_main.py
+++ b/boxes/scripts/boxes_main.py
@@ -79,7 +79,7 @@ def multi_generate(config_path : Path|str|TextIO, output_path : Path|str, output
         if box_type != "__ALL__":
             box_classes = ( generators_by_name.get(box_type, None), )
             if box_classes is None:
-                raise ValueError("invalid generator '%s'" % box_type)
+                raise ValueError(f"invalid generator '{box_type}'")
         else:
             skipGenerators = set(box_settings.get("skipGenerators", []))
             brokenGenerators = set(box_settings.get("brokenGenerators", []))

--- a/boxes/scripts/boxesserver.py
+++ b/boxes/scripts/boxesserver.py
@@ -147,7 +147,7 @@ class BServer:
         self._languages = []
         domain = "boxes.py"
         for localedir in ["locale", gettext._default_localedir]:
-            files = glob.glob(os.path.join(localedir, '*', 'LC_MESSAGES', '%s.mo' % domain))
+            files = glob.glob(os.path.join(localedir, '*', 'LC_MESSAGES', f'{domain}.mo'))
             self._languages.extend([file.split(os.path.sep)[-3] for file in files])
         self._languages.sort()
         return self._languages
@@ -195,24 +195,19 @@ class BServer:
             viewname = name[len(prefix) + 1:]
 
         default = defaults.get(name, None)
-        row = """<tr><td id="%s"><label for="%s">%s</label></td><td>%%s</td><td id="%s">%s</td></tr>\n""" % \
-              (name + "_id", name, _(viewname), name + "_description", "" if not a.help else markdown.markdown(_(a.help)))
+        row = """<tr><td id="{}"><label for="{}">{}</label></td><td>%s</td><td id="{}">{}</td></tr>\n""".format(name + "_id", name, _(viewname), name + "_description", "" if not a.help else markdown.markdown(_(a.help)))
         if (isinstance(a, argparse._StoreAction) and
                 hasattr(a.type, "html")):
             input = a.type.html(name, default or a.default, _)
         elif a.type == str and "\n" in a.default:
             val = (default or a.default).split("\n")
-            input = """<textarea name="%s" id="%s" aria-labeledby="%s %s" cols="%s" rows="%s">%s</textarea>""" % \
-                    (name, name, name + "_id", name + "_description", max(len(l) for l in val) + 10, len(val) + 1, default or a.default)
+            input = """<textarea name="{}" id="{}" aria-labeledby="{} {}" cols="{}" rows="{}">{}</textarea>""".format(name, name, name + "_id", name + "_description", max(len(l) for l in val) + 10, len(val) + 1, default or a.default)
         elif a.choices:
             options = "\n".join(
-                """    <option value="%s"%s>%s</option>""" %
-                (e, ' selected="selected"' if (e == (default or a.default)) or (str(e) == str(default or a.default)) else "",
-                 _(e)) for e in a.choices)
+                """    <option value="{}"{}>{}</option>""".format(e, ' selected="selected"' if (e == (default or a.default)) or (str(e) == str(default or a.default)) else "", _(e)) for e in a.choices)
             input = """<select name="{}" id="{}" aria-labeledby="{} {}" size="1">\n{}</select>\n""".format(name, name, name + "_id", name + "_description", options)
         else:
-            input = """<input name="%s" id="%s" aria-labeledby="%s %s" type="text" value="%s">""" % \
-                    (name, name, name + "_id", name + "_description", default or a.default)
+            input = """<input name="{}" id="{}" aria-labeledby="{} {}" type="text" value="{}">""".format(name, name, name + "_id", name + "_description", default or a.default)
 
         return row % input
 
@@ -537,7 +532,7 @@ class BServer:
         # Images do not have charset. Just bytes. Except text based svg.
         # Todo: fallback if type_ is None?
         if type_ is not None and "image" in type_ and type_ != "image/svg+xml":
-            start_response("200 OK", [('Content-type', "%s" % type_)])
+            start_response("200 OK", [('Content-type', f"{type_}")])
         else:
             start_response("200 OK", [('Content-type', f"{type_}; charset={encoding}")])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
   "mypy>=2.1.0",
   "pre-commit>=4.6.0",
   "pytest>=9.0.3",
+  "ruff",
   "types-Markdown"
 ]
 doc = ["sphinx>=8.0.2"]
@@ -69,3 +70,19 @@ ignore_directives = [
 ignore_messages = [
   "File referenced in \"include\" directive not found: '.*generators\\.inc'",
 ]
+
+[tool.ruff]
+exclude = [
+  "scripts/*ipynb", # Example
+  "scripts/boxes_proxy.py", # Symlink
+  "setup.py", # Needs refactoring so no fixes yet.
+]
+lint.select = [
+  "UP", # pyupgrade
+]
+lint.ignore = [
+  # "UP031", # ToDo
+]
+
+[tool.ruff.lint.per-file-ignores]
+#"boxes/scripts/boxesserver.py" = ["UP031"]

--- a/scripts/boxes2pot
+++ b/scripts/boxes2pot
@@ -125,15 +125,15 @@ msgstr ""
             for msg, comment, reference in self.messages:
                 f.write("\n")
                 if comment:
-                    f.write("#. %s\n" % comment)
+                    f.write(f"#. {comment}\n")
                 if reference:
-                    f.write("#: %s\n" % reference)
+                    f.write(f"#: {reference}\n")
                 msg = msg.split("\n")
                 for i in range(len(msg) - 1):
                     msg[i] += "\\n"
                 f.write('msgid ')
                 for m in msg:
-                    f.write(' "%s"\n' % m.replace('"', '\\"'))
+                    f.write(' "{}"\n'.format(m.replace('"', '\\"')))
                 f.write('msgstr ""\n')
 
 


### PR DESCRIPTION
`ruff` offers a lot of lint rules and features from popular tools: https://docs.astral.sh/ruff/rules/

For now only rules from `pyupgrade` are enabled. The lint process is different, so some more old %-style strings were found.